### PR TITLE
pktriggercord-cli: fix usleep parameter

### DIFF
--- a/pktriggercord-cli.c
+++ b/pktriggercord-cli.c
@@ -751,7 +751,7 @@ int main(int argc, char **argv) {
 		    break;
 		}
 		
-		usleep(0.1); /* 100 ms */
+		usleep(100000); /* 100 ms */
 	    }
 	} else {
 	    if( frames > 1 ) {


### PR DESCRIPTION
It should be in useconds, not seconds. 0.1 is 0 and won't sleep at all.
