### PR TITLE
Add K-3 Support (Experimental)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all: srczip rpm win pktriggercord_commandline.html
 cli: pktriggercord-cli
 
 MANS = pktriggercord-cli.1 pktriggercord.1
-SRCOBJNAMES = pslr pslr_enum pslr_scsi pslr_lens pslr_model pktriggercord-servermode 
+SRCOBJNAMES = pslr pslr_enum pslr_scsi pslr_lens pslr_model pktriggercord-servermode
 OBJS = $(SRCOBJNAMES:=.o)
 WIN_DLLS_DIR=win_dlls
 SOURCE_PACKAGE_FILES = Makefile Changelog COPYING INSTALL BUGS $(MANS) pentax.rules samsung.rules $(SRCOBJNAMES:=.h) $(SRCOBJNAMES:=.c) pslr_scsi_linux.c pslr_scsi_win.c exiftool_pentax_lens.txt pktriggercord.c pktriggercord-cli.c pktriggercord.ui $(SPECFILE) android_scsi_sg.h
@@ -52,15 +52,15 @@ WINDIR=$(TARDIR)-win
 pslr.o: pslr_enum.o pslr_scsi.o pslr.c pslr.h
 
 pktriggercord-cli: pktriggercord-cli.c $(OBJS)
-	$(CC) $(LIN_CFLAGS) $^ -DVERSION='"$(VERSION)"' -o $@ $(LIN_LDFLAGS) -L. 
+	$(CC) $(LIN_CFLAGS) $^ -DVERSION='"$(VERSION)"' -o $@ $(LIN_LDFLAGS) -L.
 
 %.o : %.c %.h
 	$(CC) $(LIN_CFLAGS) -fPIC -c $<
 
 pktriggercord: pktriggercord.c $(OBJS)
-	$(CC) $(LIN_GUI_CFLAGS) -DVERSION='"$(VERSION)"' -DDATADIR=\"$(PREFIX)/share/pktriggercord\" $? $(LIN_LDFLAGS) -o $@ $(LIN_GUI_LDFLAGS) -L. 
+	$(CC) $(LIN_GUI_CFLAGS) -DVERSION='"$(VERSION)"' -DDATADIR=\"$(PREFIX)/share/pktriggercord\" $? $(LIN_LDFLAGS) -o $@ $(LIN_GUI_LDFLAGS) -L.
 
-install:
+install: pktriggercord-cli pktriggercord
 	install -d $(DESTDIR)/$(PREFIX)/bin
 	install -s -m 0755 pktriggercord-cli $(DESTDIR)/$(PREFIX)/bin/
 	(which setcap && setcap CAP_SYS_RAWIO+eip $(DESTDIR)/$(PREFIX)/bin/pktriggercord-cli) || true
@@ -123,7 +123,7 @@ rpm: srcrpm
 	cp $(TOPDIR)/RPMS/$(ARCH)/pktriggercord-$(VERSION)-1.$(ARCH).rpm .
 
 WIN_CFLAGS=$(CFLAGS) -I$(WINMINGW)/include/gtk-2.0/ -I$(WINMINGW)/lib/gtk-2.0/include/ -I$(WINMINGW)/include/atk-1.0/ -I$(WINMINGW)/include/cairo/ -I$(WINMINGW)/include/gdk-pixbuf-2.0/ -I$(WINMINGW)/include/pango-1.0/
-WIN_GUI_CFLAGS=$(WIN_CFLAGS) -I$(WINMINGW)/include/glib-2.0 -I$(WINMINGW)/lib/glib-2.0/include 
+WIN_GUI_CFLAGS=$(WIN_CFLAGS) -I$(WINMINGW)/include/glib-2.0 -I$(WINMINGW)/lib/glib-2.0/include
 WIN_LDFLAGS=-lgtk-win32-2.0 -lgdk-win32-2.0 -lgdk_pixbuf-2.0 -lgobject-2.0 -lglib-2.0 -lgio-2.0
 
 deb: srczip
@@ -197,4 +197,3 @@ android: androidcli androidver $(ANDROID_DIR)/build.xml
 	ant "-Djava.compilerargs=-Xlint:unchecked -Xlint:deprecation" -f $(ANDROID_ANT_FILE) debug
 	cp $(ANDROID_DIR)/bin/$(ANDROID_PROJECT_NAME)-debug.apk $(ANDROID_PROJECT_NAME)-$(VERSION)-debug.apk
 	echo "android build is EXPERIMENTAL. Use it at your own risk"
-

--- a/pentax.rules
+++ b/pentax.rules
@@ -8,6 +8,7 @@ LABEL="pentax_rules_start"
 # WAIT_FOR_SYSFS="device/vendor"
 ATTRS{vendor}=="PENTAX", ATTRS{model}=="DIGITAL_CAMERA", MODE="0666", GROUP="plugdev"
 ATTRS{vendor}=="PENTAX", ATTRS{model}=="DSC*", MODE="0666", GROUP="plugdev"
+ATTRS{vendor}=="RICOHIMG", ATTRS{model}=="DSC*", MODE="0666", GROUP="plugdev"
 ATTRS{vendor}=="PENTAX", ATTRS{model}=="K*", MODE="0666", GROUP="plugdev"
 
 LABEL="pentax_rules_end"

--- a/pktriggercord-cli.c
+++ b/pktriggercord-cli.c
@@ -827,8 +827,12 @@ int save_buffer(pslr_handle_t camhandle, int bufno, int fd, pslr_status *status,
             break;
       	}
         ssize_t r = write(fd, buf, bytes);
-        if (r != 0) {
-          fprintf(stderr, "write(buf) failed");
+        if (r == 0) {
+            DPRINT("write(buf): Nothing has been written to buf.\n");
+        } else if (r == -1) {
+            perror("write(buf)");
+        } else if (r < bytes) {
+            DPRINT("write(buf): only write %d bytes, should be %d bytes.\n", r, bytes);
         }
         current += bytes;
     }

--- a/pktriggercord-cli.c
+++ b/pktriggercord-cli.c
@@ -9,11 +9,11 @@
 
     Command line remote control of Pentax DSLR cameras.
     Copyright (C) 2009 Ramiro Barreiro <ramiro_barreiro69@yahoo.es>
-    With fragments of code from PK-Remote by Pontus Lidman. 
+    With fragments of code from PK-Remote by Pontus Lidman.
     <https://sourceforge.net/projects/pkremote>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by 
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
@@ -27,7 +27,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdbool.h>  
+#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -114,7 +114,7 @@ int open_file(char* output_file, int frameNo, user_file_format_t ufft) {
 
     if (!output_file) {
         ofd = 1;
-    } else {       
+    } else {
         snprintf(fileName, 256, "%s-%04d.%s", output_file, frameNo, ufft.extension);
         ofd = open(fileName, FILE_ACCESS, 0664);
         if (ofd == -1) {
@@ -227,7 +227,7 @@ int main(int argc, char **argv) {
     // parse all the other flags
     while ((optc = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
         switch (optc) {
-	    case '?': 
+	    case '?':
 	    case 'h':
                 usage(argv[0]);
                 exit(-1);
@@ -260,7 +260,7 @@ int main(int argc, char **argv) {
             case 2:
                 status_hex_info = true;
                 break;
-		
+
             case 'm':
 
                 MODESTRING = optarg;
@@ -512,7 +512,7 @@ int main(int argc, char **argv) {
         // ignore all the other argument and go to server mode
         servermode_socket(servermode_timeout);
         exit(0);
-    } 
+    }
 #endif
 
     if (!output_file && frames > 1) {
@@ -676,7 +676,7 @@ int main(int argc, char **argv) {
     if (green) {
         pslr_green_button( camhandle );
     }
-    
+
 //    pslr_test( camhandle, true, 0x1e, 4, 1, 2, 3, 4);
 //    pslr_button_test( camhandle, 0x0c, 1 );
 //    pslr_button_test( camhandle, 0x05, 2 );
@@ -729,7 +729,7 @@ int main(int argc, char **argv) {
 	    }
 	    waitsec = 1.0 * delay - timeval_diff(&current_time, &prev_time) / 1000000.0;
 	    if( waitsec > 0 ) {
-		printf("Waiting for %.2f sec\n", waitsec);	   
+		printf("Waiting for %.2f sec\n", waitsec);
 		sleep_sec( waitsec );
 	    }
 	    bracket_index = 0;
@@ -750,7 +750,7 @@ int main(int argc, char **argv) {
 		    printf("Timeout %d sec passed!\n", timeout);
 		    break;
 		}
-		
+
 		usleep(0.1); /* 100 ms */
 	    }
 	} else {
@@ -825,15 +825,18 @@ int save_buffer(pslr_handle_t camhandle, int bufno, int fd, pslr_status *status,
         bytes = pslr_buffer_read(camhandle, buf, sizeof (buf));
         if (bytes == 0) {
             break;
-	}
-        write(fd, buf, bytes);
+      	}
+        ssize_t r = write(fd, buf, bytes);
+        if (r != 0) {
+          fprintf(stderr, "write(buf) failed");
+        }
         current += bytes;
     }
     pslr_buffer_close(camhandle);
     return (0);
 }
 
-void print_status_info( pslr_handle_t h, pslr_status status ) {    
+void print_status_info( pslr_handle_t h, pslr_status status ) {
     printf("\n");
     printf( "%s", collect_status_info( h, status ) );
 }
@@ -896,4 +899,3 @@ Based on:\n\
 pslr-shoot (C) 2009 Ramiro Barreiro\n\
 PK-Remote (C) 2008 Pontus Lidman \n\n", name, VERSION);
 }
-

--- a/pktriggercord.c
+++ b/pktriggercord.c
@@ -9,7 +9,7 @@
     Copyright (C) 2008 Pontus Lidman <pontus@lysator.liu.se>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by 
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
@@ -166,7 +166,7 @@ static pslr_rational_t shutter_tbl_1_2[] = {
 
 
 static const int iso_tbl_1_3[] = {
-    80, 100, 125, 160, 200, 250, 320, 400, 500, 640, 800, 1000, 1250, 1600, 2000, 2500, 
+    80, 100, 125, 160, 200, 250, 320, 400, 500, 640, 800, 1000, 1250, 1600, 2000, 2500,
     3200, 4000, 5000, 6400, 8000, 10000, 12800, 16000, 20000, 25600, 32000, 40000, 51200
 };
 
@@ -257,7 +257,7 @@ int common_init(void)
 	  return -1;
 	}
       }
-    }    
+    }
 
     init_preview_area();
 
@@ -321,7 +321,7 @@ void shutter_speed_table_init(pslr_status *st) {
     if( tbl[max_valid_shutter_speed_index].denom != fastest_shutter_speed ) {
         // not an exact match
         ++max_valid_shutter_speed_index;
-        tbl[max_valid_shutter_speed_index].denom = fastest_shutter_speed; 	
+        tbl[max_valid_shutter_speed_index].denom = fastest_shutter_speed;
     }
     GtkWidget *pw;
     pw = GTK_WIDGET (gtk_builder_get_object (xml, "shutter_scale"));
@@ -331,7 +331,7 @@ void shutter_speed_table_init(pslr_status *st) {
 }
 
 void iso_speed_table_init(pslr_status *st) {
-    GtkWidget *pw;    
+    GtkWidget *pw;
     pw = GTK_WIDGET (gtk_builder_get_object (xml, "iso_scale"));
 
     const int *tbl = 0;
@@ -371,7 +371,7 @@ void camera_specific_init() {
     char **str_resolutions = malloc( MAX_RESOLUTION_SIZE * sizeof( char * ));
     while( resindex < MAX_RESOLUTION_SIZE ) {
         str_resolutions[resindex] = malloc( 10 );
-        sprintf( str_resolutions[resindex], "%dM", resolutions[resindex]); 
+        sprintf( str_resolutions[resindex], "%dM", resolutions[resindex]);
 	++resindex;
     }
 
@@ -396,7 +396,7 @@ void camera_specific_init() {
     int max_supported_image_tone = pslr_get_model_max_supported_image_tone( camhandle )+1;
     DPRINT("max image tone:%d", max_supported_image_tone);
     GtkComboBox *pw = (GtkComboBox*)GTK_WIDGET (gtk_builder_get_object (xml, "jpeg_image_tone_combo"));
-        
+
     char **imagetones = malloc( max_supported_image_tone * sizeof(char*) );
     int i;
     for (i = 0; i<max_supported_image_tone; i++) {
@@ -409,7 +409,7 @@ void camera_specific_init() {
     combobox_append( pw, imagetones, max_supported_image_tone );
 
     gtk_widget_set_sensitive( GTK_WIDGET(pw), max_supported_image_tone > -1 );
-}   
+}
 
 static void init_controls(pslr_status *st_new, pslr_status *st_old)
 {
@@ -459,7 +459,7 @@ static void init_controls(pslr_status *st_new, pslr_status *st_old)
     if (st_new) {
         idx = -1;
 	pslr_rational_t *tbl = 0;
-        int steps = 0;    
+        int steps = 0;
         which_shutter_table( st_new, &tbl, &steps );
         for (i=0; i<steps; i++) {
             if (st_new->set_shutter_speed.nom == tbl[i].nom
@@ -511,7 +511,7 @@ static void init_controls(pslr_status *st_new, pslr_status *st_old)
         }
         if (!st_old || st_old->custom_ev_steps != st_new->custom_ev_steps)
             gtk_range_set_range(GTK_RANGE(pw), 0.0, steps-1);
-        if (!st_old || st_old->ec.nom != st_new->ec.nom 
+        if (!st_old || st_old->ec.nom != st_new->ec.nom
             || st_old->ec.denom != st_new->ec.denom)
             gtk_range_set_value(GTK_RANGE(pw), idx);
     }
@@ -550,19 +550,19 @@ static void init_controls(pslr_status *st_new, pslr_status *st_old)
 
     gtk_widget_set_sensitive(pw, st_new != NULL);
     /* JPEG quality */
-    
+
     pw = GW("jpeg_quality_combo");
     if (st_new) {
         GtkTreeModel *jpeg_quality_model = gtk_combo_box_get_model(GTK_COMBO_BOX(pw));
         gint jpeg_quality_num = gtk_tree_model_iter_n_children( jpeg_quality_model, NULL );
 	ipslr_handle_t *p = (ipslr_handle_t *)camhandle;
-	int hw_jpeg_quality = get_hw_jpeg_quality(p->model, st_new->jpeg_quality);	
+	int hw_jpeg_quality = get_hw_jpeg_quality(p->model, st_new->jpeg_quality);
         if( st_new->jpeg_quality >= jpeg_quality_num ) {
 	  hw_jpeg_quality = 0;
 	}
 	gtk_combo_box_set_active(GTK_COMBO_BOX(pw), hw_jpeg_quality);
     }
-    
+
     gtk_widget_set_sensitive(pw, st_new != NULL);
     /* JPEG resolution */
     pw = GTK_WIDGET (gtk_builder_get_object (xml, "jpeg_resolution_combo"));
@@ -591,7 +591,7 @@ static void init_controls(pslr_status *st_new, pslr_status *st_old)
     pw = GTK_WIDGET (gtk_builder_get_object (xml, "file_format_combo"));
     if (st_new) {
         int val = get_user_file_format(st_new);
-        gtk_combo_box_set_active(GTK_COMBO_BOX(pw), val);        
+        gtk_combo_box_set_active(GTK_COMBO_BOX(pw), val);
     }
 
     gtk_widget_set_sensitive(pw, st_new != NULL);
@@ -739,14 +739,14 @@ static gboolean status_poll(gpointer data)
     }
 
     /* EV label */
-    if (status_new && status_new->current_aperture.denom 
+    if (status_new && status_new->current_aperture.denom
         && status_new->current_shutter_speed.denom) {
         float ev, a, s;
         a = (float)status_new->current_aperture.nom/(float)status_new->current_aperture.denom;
         s = (float)status_new->current_shutter_speed.nom/(float)status_new->current_shutter_speed.denom;
 
         ev = log(a*a/s)/M_LN2 - log(status_new->current_iso/100)/M_LN2;
-    
+
         sprintf(buf, "<span size=\"xx-large\">EV %.2f</span>", ev);
         pw = GTK_WIDGET (gtk_builder_get_object (xml, "label_ev"));
         gtk_label_set_markup(GTK_LABEL(pw), buf);
@@ -785,7 +785,7 @@ static gboolean status_poll(gpointer data)
             /* Same as previous check, stop indicating */
             focus_indicated_af_points = 0;
             gdk_window_invalidate_rect(pw->window, &pw->allocation, FALSE);
-        } 
+        }
 
         if (!status_old || status_old->selected_af_point != status_new->selected_af_point) {
             /* Change in selected AF points */
@@ -951,8 +951,8 @@ static bool auto_save_check(int format, int buffer)
         old_path = getcwd(NULL, 0);
         if (chdir(plugin_config.autosave_path) == -1) {
             char msg[256];
-            
-            snprintf(msg, sizeof(msg), "Could not save in folder %s: %s", 
+
+            snprintf(msg, sizeof(msg), "Could not save in folder %s: %s",
                      plugin_config.autosave_path, strerror(errno));
             error_message(msg);
             free(old_path);
@@ -1000,7 +1000,11 @@ static bool auto_save_check(int format, int buffer)
     gtk_spin_button_set_value(spin, counter);
 
     if (old_path) {
-        chdir(old_path);
+        ssize_t r = chdir(old_path);
+        if (r != 0) {
+          fprintf(stderr, "chdir(old_path) failed");
+        }
+
         free(old_path);
     }
 
@@ -1043,7 +1047,7 @@ static void update_main_area(int buffer)
     g_object_ref(pixBuf);
     pError = NULL;
     pMainPixbuf = pixBuf;
-    
+
   the_end:
     gtk_statusbar_pop(statusbar, sbar_download_ctx);
 
@@ -1059,7 +1063,7 @@ static void update_preview_area(int buffer)
     //    GtkWidget *pw;
 
     //    pw = GTK_WIDGET (gtk_builder_get_object (xml, "test_draw_area"));
-    
+
     gtk_statusbar_push(statusbar, sbar_download_ctx, "Getting thumbnails");
     while (gtk_events_pending())
         gtk_main_iteration();
@@ -1188,7 +1192,7 @@ G_MODULE_EXPORT int mainwindow_expose(GtkAction *action, gpointer userData)
                 the_gc = gc_presel;
         }
         fill = focus_indicated_af_points & (1<<i) ? TRUE : FALSE;
-        gdk_draw_rectangle(pw->window, the_gc, fill, 
+        gdk_draw_rectangle(pw->window, the_gc, fill,
                            af_points[i].x, af_points[i].y,
                            af_points[i].w, af_points[i].h);
     }
@@ -1232,7 +1236,7 @@ G_MODULE_EXPORT gboolean main_drawing_area_button_press_event_cb(GtkAction *acti
                 preselect_reselect = false;
             }
             pw = GTK_WIDGET (gtk_builder_get_object (xml, "main_drawing_area"));
-            gdk_window_invalidate_rect(pw->window, &pw->allocation, FALSE);            
+            gdk_window_invalidate_rect(pw->window, &pw->allocation, FALSE);
             while (gtk_events_pending())
                 gtk_main_iteration();
             if (status_new && status_new->af_point_select == PSLR_AF_POINT_SEL_SELECT) {
@@ -1334,7 +1338,7 @@ GdkPixmap *calculate_histogram( GdkPixbuf *input, int hist_w, int hist_h ) {
                 scale = histogram[x][y];
         }
     }
-    // draw onto 
+    // draw onto
     GdkPixmap *output = gdk_pixmap_new( NULL, hist_w, 3*hist_h, 24);
     gc = gdk_gc_new(output);
     gdk_gc_set_rgb_fg_color(gc, &cWhite);
@@ -1432,7 +1436,7 @@ G_MODULE_EXPORT void status_button_clicked_cb(GtkAction *action)
 {
     DPRINT("Status");
     GtkWidget *pw;
-    pslr_status st;    
+    pslr_status st;
 
     pslr_get_status(camhandle, &st);
 
@@ -1550,7 +1554,7 @@ void init_preview_area(void)
     list_store = gtk_list_store_new (3,
                                      GDK_TYPE_PIXBUF, // thumbnail
 				     GDK_TYPE_PIXMAP, // histogram
-				     GDK_TYPE_PIXBUF  // visible icon 
+				     GDK_TYPE_PIXBUF  // visible icon
 	);
 
     for (i = 0; i < MAX_BUFFERS; i++) {
@@ -1572,7 +1576,7 @@ GdkPixbuf *merge_preview_icons( GdkPixbuf *thumb, GdkPixmap *histogram ) {
 	GdkPixbuf *scaledThumb = gdk_pixbuf_scale_simple( thumb, HISTOGRAM_WIDTH, HISTOGRAM_HEIGHT, GDK_INTERP_BILINEAR);
 	gdk_draw_pixbuf( mMerged, gc, scaledThumb, 0, 0, 0, 0, HISTOGRAM_WIDTH, HISTOGRAM_HEIGHT, GDK_RGB_DITHER_NONE, 0, 0);
 	gdk_draw_drawable( mMerged, gc, histogram, 0, 0, HISTOGRAM_WIDTH, 0, HISTOGRAM_WIDTH, HISTOGRAM_HEIGHT);
-	GdkPixbuf *pMerged = gdk_pixbuf_get_from_drawable( NULL, mMerged, GDK_COLORSPACE_RGB, 0, 0, 0, 0, 2*HISTOGRAM_WIDTH, HISTOGRAM_HEIGHT ); 
+	GdkPixbuf *pMerged = gdk_pixbuf_get_from_drawable( NULL, mMerged, GDK_COLORSPACE_RGB, 0, 0, 0, 0, 2*HISTOGRAM_WIDTH, HISTOGRAM_HEIGHT );
 	output = gdk_pixbuf_scale_simple( pMerged, 2*THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, GDK_INTERP_BILINEAR);
     } else {
 	output = thumb;
@@ -1628,7 +1632,7 @@ G_MODULE_EXPORT gchar* shutter_scale_format_value_cb(GtkAction *action, gdouble 
     //printf("shutter value: %f\n", value);
 
     pslr_rational_t *tbl = 0;
-    int steps = 0;    
+    int steps = 0;
     if (!status_new) {
 	return g_strdup_printf("(%f)", value);
     }
@@ -1683,7 +1687,7 @@ G_MODULE_EXPORT gchar* ec_scale_format_value_cb(GtkAction *action, gdouble value
         which_ec_table(status_new, &tbl, &steps);
         if (i >= 0 && i < steps) {
             return g_strdup_printf("%.1f", tbl[i]/10.0);
-        } 
+        }
     }
     return g_strdup_printf("(%f)", value);
 }
@@ -2005,7 +2009,11 @@ static void save_buffer(int bufno, const char *filename)
         //printf("Read %d bytes\n", bytes);
         if (bytes == 0)
             break;
-        write(fd, buf, bytes);
+        ssize_t r = write(fd, buf, bytes);
+        if (r != 0) {
+          fprintf(stderr, "write(buf) failed");
+        }
+
         current += bytes;
         gtk_progress_bar_update(GTK_PROGRESS_BAR(pw), (gdouble) current / (gdouble) length);
         /* process pending events */
@@ -2111,7 +2119,7 @@ G_MODULE_EXPORT void file_format_combo_changed_cb(GtkAction *action, gpointer us
 
 G_MODULE_EXPORT void user_mode_combo_changed_cb(GtkAction *action, gpointer user_data)
 {
-    DPRINT("user_mode_combo_changed_cb\n");  
+    DPRINT("user_mode_combo_changed_cb\n");
     pslr_gui_exposure_mode_t val = gtk_combo_box_get_active(GTK_COMBO_BOX(GW("user_mode_combo")));
     if (!status_new) {
         return;
@@ -2128,7 +2136,7 @@ G_MODULE_EXPORT void user_mode_combo_changed_cb(GtkAction *action, gpointer user
 
 static void which_iso_table(pslr_status *st, const int **table, int *steps)
 {
-    if (st->custom_sensitivity_steps == PSLR_CUSTOM_SENSITIVITY_STEPS_1EV) { 
+    if (st->custom_sensitivity_steps == PSLR_CUSTOM_SENSITIVITY_STEPS_1EV) {
         *table = iso_tbl_1;
         *steps = sizeof(iso_tbl_1)/sizeof(iso_tbl_1[0]);
     }else if (st->custom_ev_steps == PSLR_CUSTOM_EV_STEPS_1_2) {

--- a/pktriggercord.c
+++ b/pktriggercord.c
@@ -2010,10 +2010,14 @@ static void save_buffer(int bufno, const char *filename)
         if (bytes == 0)
             break;
         ssize_t r = write(fd, buf, bytes);
-        if (r != 0) {
-          fprintf(stderr, "write(buf) failed");
+        if (r == 0) {
+            DPRINT("write(buf): Nothing has been written to buf.\n");
+        } else if (r == -1) {
+            perror("write(buf)");
+        } else if (r < bytes) {
+            DPRINT("write(buf): only write %d bytes, should be %d bytes.\n", r, bytes);
         }
-
+        
         current += bytes;
         gtk_progress_bar_update(GTK_PROGRESS_BAR(pw), (gdouble) current / (gdouble) length);
         /* process pending events */

--- a/pslr.c
+++ b/pslr.c
@@ -1361,9 +1361,9 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
 
             //  For some reason, the endian of the args is not as same as model's.
             if (p->model != NULL && p->model->is_little_endian) {
-                put_uint32_be(data, &buf[4*i]);
+                set_uint32_be(data, &buf[4*i]);
             } else {
-                put_uint32_le(data, &buf[4*i]);
+                set_uint32_le(data, &buf[4*i]);
             }
         }
         cmd[4] = 4 * n;
@@ -1379,9 +1379,9 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
             data = va_arg(ap, uint32_t);
 
             if (p->model != NULL && p->model->is_little_endian) {
-                put_uint32_be(data, &buf[0]);
+                set_uint32_be(data, &buf[0]);
             } else {
-                put_uint32_le(data, &buf[0]);
+                set_uint32_le(data, &buf[0]);
             }
 
             cmd[4] = 4;
@@ -1434,12 +1434,10 @@ static int get_status(int fd) {
     while (1) {
         //usleep(POLL_INTERVAL);
         CHECK(read_status(fd, statusbuf));
-        // DPRINT("get_status->\n");
-        // hexdump_debug(statusbuf, 8);
         if ((statusbuf[7] & 0x01) == 0)
             break;
         //DPRINT("Waiting for ready - ");
-        //hexdump_debug(statusbuf, 8);
+        DPRINT("[R]\t\t\t\t => ERROR: 0x%02X\n", statusbuf[7]);
         usleep(POLL_INTERVAL);
     }
     if ((statusbuf[7] & 0xff) != 0) {
@@ -1476,10 +1474,7 @@ static int read_result(int fd, uint8_t *buf, uint32_t n) {
     uint8_t cmd[8] = {0xf0, 0x49, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     int r;
     int i;
-    cmd[4] = n;
-    cmd[5] = n >> 8;
-    cmd[6] = n >> 16;
-    cmd[7] = n >> 24;
+    set_uint32_le(n, &cmd[4]);
     r = scsi_read(fd, cmd, sizeof (cmd), buf, n);
     if (r != n) {
         return PSLR_READ_ERROR;

--- a/pslr.c
+++ b/pslr.c
@@ -19,7 +19,7 @@
     Copyright (C) 2010 Tomasz Kos
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by 
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
@@ -240,7 +240,7 @@ static int ipslr_cmd_23_04(ipslr_handle_t *p) {
 /* function disables debug mode, else debug mode is enabled                  */
 int debug_onoff(ipslr_handle_t *p, char debug_mode){
     uint8_t buf[16]; /* buffer for storing statuses and read_results */
-    
+
     ipslr_cmd_00_09(p,1);
 
     ipslr_cmd_23_XX(p,0x07,0x04,3);
@@ -271,7 +271,7 @@ int debug_onoff(ipslr_handle_t *p, char debug_mode){
 /* ************* End enabling/disabling debug mode ************ */
 
 user_file_format_t *get_file_format_t( user_file_format uff ) {
-    int i;    
+    int i;
     for (i = 0; i<sizeof(file_formats) / sizeof(file_formats[0]); i++) {
         if (file_formats[i].uff == uff) {
             return &file_formats[i];
@@ -316,7 +316,7 @@ user_file_format get_user_file_format( pslr_status *st ) {
 // most of the cameras require this exposure mode conversion step
 pslr_gui_exposure_mode_t exposure_mode_conversion( pslr_exposure_mode_t exp ) {
     switch( exp ) {
-    
+
     case PSLR_EXPOSURE_MODE_GREEN:
 	return PSLR_GUI_EXPOSURE_MODE_GREEN;
     case PSLR_EXPOSURE_MODE_P:
@@ -340,7 +340,7 @@ pslr_gui_exposure_mode_t exposure_mode_conversion( pslr_exposure_mode_t exp ) {
 	return PSLR_GUI_EXPOSURE_MODE_X;
     case PSLR_EXPOSURE_MODE_MAX:
 	return PSLR_GUI_EXPOSURE_MODE_MAX;
-    }    
+    }
     return 0;
 }
 
@@ -366,7 +366,7 @@ pslr_handle_t pslr_init( char *model, char *device ) {
 	pslr_result result = get_drive_info( drives[i], &fd, vendorId, sizeof(vendorId), productId, sizeof(productId));
 
 	DPRINT("Checking drive:  %s %s %s\n", drives[i], vendorId, productId);
-	if( find_in_array( valid_vendors, sizeof(valid_vendors)/sizeof(valid_vendors[0]),vendorId) != -1 
+	if( find_in_array( valid_vendors, sizeof(valid_vendors)/sizeof(valid_vendors[0]),vendorId) != -1
 	    && find_in_array( valid_models, sizeof(valid_models)/sizeof(valid_models[0]), productId) != -1 ) {
 	    if( result == PSLR_OK ) {
 		DPRINT("Found camera %s %s\n", vendorId, productId);
@@ -376,7 +376,7 @@ pslr_handle_t pslr_init( char *model, char *device ) {
 		    camera_name = pslr_camera_name( &pslr );
 		    DPRINT("Name of the camera: %s\n", camera_name);
 		    if( str_comparison_i( camera_name, model, strlen( camera_name) ) == 0 ) {
-			return &pslr;	    
+			return &pslr;
 		    } else {
 			DPRINT("Ignoring camera %s %s\n", vendorId, productId);
 			pslr_shutdown ( &pslr );
@@ -384,7 +384,7 @@ pslr_handle_t pslr_init( char *model, char *device ) {
 			pslr.model = NULL;
 		    }
 		} else {
-		    return &pslr;	    
+		    return &pslr;
 		}
 	    } else {
 		DPRINT("Cannot get drive info of Pentax camera. Please do not forget to install the program using 'make install'\n");
@@ -411,7 +411,7 @@ int pslr_connect(pslr_handle_t h) {
     if( !p->model ) {
       DPRINT("Unknown Pentax camera.\n");
       return 1;
-    }      
+    }
     CHECK(ipslr_status_full(p, &p->status));
     DPRINT("init bufmask=0x%x\n", p->status.bufmask);
     if( !p->model->old_scsi_command ) {
@@ -488,9 +488,9 @@ char *get_white_balance_adjust_str( uint32_t adjust_mg, uint32_t adjust_ba ) {
 	ret = "0";
     }
     return ret;
-}  
+}
 
-char *collect_status_info( pslr_handle_t h, pslr_status status ) {    
+char *collect_status_info( pslr_handle_t h, pslr_status status ) {
     char *strbuffer = malloc(8192);
     sprintf(strbuffer,"%-32s: %d\n", "current iso", status.current_iso);
     sprintf(strbuffer+strlen(strbuffer),"%-32s: %d/%d\n", "current shutter speed", status.current_shutter_speed.nom, status.current_shutter_speed.denom);
@@ -559,7 +559,7 @@ int pslr_get_buffer(pslr_handle_t h, int bufno, pslr_buffer_type type, int resol
     }
 
     uint32_t size = pslr_buffer_get_size(h);
-    buf = malloc(size); 
+    buf = malloc(size);
     if (!buf) {
 	return PSLR_NO_MEMORY;
     }
@@ -575,7 +575,7 @@ int pslr_get_buffer(pslr_handle_t h, int bufno, pslr_buffer_type type, int resol
     }
     if (pLen) {
 	*pLen = size;
-    }    
+    }
 
     return PSLR_OK;
 }
@@ -586,6 +586,7 @@ int pslr_set_progress_callback(pslr_handle_t h, pslr_progress_callback_t cb, uin
 }
 
 int ipslr_handle_command_x18( ipslr_handle_t *p, bool cmd9_wrap, int subcommand, int argnum,  ...) {
+    DPRINT("ipslr_handle_command_x18(0x%x, %d)\n", subcommand, argnum);
     if( cmd9_wrap ) {
         CHECK(ipslr_cmd_00_09(p, 1));
     }
@@ -653,27 +654,27 @@ int pslr_set_flash_mode(pslr_handle_t h, pslr_flash_mode_t value) {
 
 int pslr_set_flash_exposure_compensation(pslr_handle_t h, pslr_rational_t value) {
     ipslr_handle_t *p = (ipslr_handle_t *) h;
-    return ipslr_handle_command_x18( p, true, X18_FLASH_EXPOSURE_COMPENSATION, 2, value.nom, value.denom, 0);    
+    return ipslr_handle_command_x18( p, true, X18_FLASH_EXPOSURE_COMPENSATION, 2, value.nom, value.denom, 0);
 }
 
 int pslr_set_drive_mode(pslr_handle_t h, pslr_drive_mode_t drive_mode) {
     ipslr_handle_t *p = (ipslr_handle_t *) h;
-    return ipslr_handle_command_x18( p, true, X18_DRIVE_MODE, 1, drive_mode, 0, 0);    
+    return ipslr_handle_command_x18( p, true, X18_DRIVE_MODE, 1, drive_mode, 0, 0);
 }
 
 int pslr_set_ae_metering_mode(pslr_handle_t h, pslr_ae_metering_t ae_metering_mode) {
     ipslr_handle_t *p = (ipslr_handle_t *) h;
-    return ipslr_handle_command_x18( p, true, X18_AE_METERING_MODE, 1, ae_metering_mode, 0, 0);    
+    return ipslr_handle_command_x18( p, true, X18_AE_METERING_MODE, 1, ae_metering_mode, 0, 0);
 }
 
 int pslr_set_af_mode(pslr_handle_t h, pslr_af_mode_t af_mode) {
     ipslr_handle_t *p = (ipslr_handle_t *) h;
-    return ipslr_handle_command_x18( p, true, X18_AF_MODE, 1, af_mode, 0, 0);    
+    return ipslr_handle_command_x18( p, true, X18_AF_MODE, 1, af_mode, 0, 0);
 }
 
 int pslr_set_af_point_sel(pslr_handle_t h, pslr_af_point_sel_t af_point_sel) {
     ipslr_handle_t *p = (ipslr_handle_t *) h;
-    return ipslr_handle_command_x18( p, true, X18_AF_POINT_SEL, 1, af_point_sel, 0, 0);    
+    return ipslr_handle_command_x18( p, true, X18_AF_POINT_SEL, 1, af_point_sel, 0, 0);
 }
 
 int pslr_set_jpeg_stars(pslr_handle_t h, int jpeg_stars ) {
@@ -858,6 +859,8 @@ int pslr_buffer_open(pslr_handle_t h, int bufno, pslr_buffer_type buftype, int b
 
     CHECK(ipslr_status_full(p, &p->status));
     bufs = p->status.bufmask;
+    DPRINT("p->status.bufmask = %x\n", p->status.bufmask);
+
     if( p->model->parser_function && (bufs & (1 << bufno)) == 0) {
 	// do not check this for limited support cameras
         DPRINT("No buffer data (%d)\n", bufno);
@@ -937,7 +940,7 @@ uint32_t pslr_buffer_read(pslr_handle_t h, uint8_t *buf, uint32_t size) {
     if (blksz > BLKSZ)
         blksz = BLKSZ;
 
-//    DPRINT("File offset %d segment: %d offset %d address 0x%x read size %d\n", p->offset, 
+//    DPRINT("File offset %d segment: %d offset %d address 0x%x read size %d\n", p->offset,
 //           i, seg_offs, addr, blksz);
 
     ret = ipslr_download(p, addr, blksz, buf);
@@ -1061,6 +1064,7 @@ pslr_buffer_type pslr_get_jpeg_buffer_type(pslr_handle_t h, int jpeg_stars) {
 /* ----------------------------------------------------------------------- */
 
 static int ipslr_set_mode(ipslr_handle_t *p, uint32_t mode) {
+    DPRINT("ipslr_set_mode(0x%x)\n", mode);
     CHECK(ipslr_write_args(p, 1, mode));
     CHECK(command(p->fd, 0, 0, 4));
     CHECK(get_status(p->fd));
@@ -1068,6 +1072,7 @@ static int ipslr_set_mode(ipslr_handle_t *p, uint32_t mode) {
 }
 
 static int ipslr_cmd_00_09(ipslr_handle_t *p, uint32_t mode) {
+    DPRINT("ipslr_cmd_00_09(0x%x)\n", mode);
     CHECK(ipslr_write_args(p, 1, mode));
     CHECK(command(p->fd, 0, 9, 4));
     CHECK(get_status(p->fd));
@@ -1075,6 +1080,7 @@ static int ipslr_cmd_00_09(ipslr_handle_t *p, uint32_t mode) {
 }
 
 static int ipslr_cmd_10_0a(ipslr_handle_t *p, uint32_t mode) {
+    DPRINT("ipslr_cmd_10_0a(0x%x)\n", mode);
     CHECK(ipslr_write_args(p, 1, mode));
     CHECK(command(p->fd, 0x10, X10_CONNECT, 4));
     CHECK(get_status(p->fd));
@@ -1082,6 +1088,7 @@ static int ipslr_cmd_10_0a(ipslr_handle_t *p, uint32_t mode) {
 }
 
 static int ipslr_cmd_00_05(ipslr_handle_t *p) {
+    DPRINT("ipslr_cmd_00_05()\n");
     int n;
     uint8_t buf[0xb8];
     CHECK(command(p->fd, 0x00, 0x05, 0x00));
@@ -1096,6 +1103,7 @@ static int ipslr_cmd_00_05(ipslr_handle_t *p) {
 
 static int ipslr_status(ipslr_handle_t *p, uint8_t *buf) {
     int n;
+    DPRINT("ipslr_status()\n");
     CHECK(command(p->fd, 0, 1, 0));
     n = get_result(p->fd);
     if (n == 16 || n == 28) {
@@ -1107,12 +1115,13 @@ static int ipslr_status(ipslr_handle_t *p, uint8_t *buf) {
 
 static int ipslr_status_full(ipslr_handle_t *p, pslr_status *status) {
     int n;
+    DPRINT("ipslr_status_full()\n");
     CHECK(command(p->fd, 0, 8, 0));
     n = get_result(p->fd);
     DPRINT("read %d bytes\n", n);
     int expected_bufsize = p->model != NULL ? p->model->buffer_size : 0;
     if( p->model == NULL ) {
-      DPRINT("p model null\n");     
+      DPRINT("p model null\n");
     }
     DPRINT("expected_bufsize: %d\n",expected_bufsize);
 
@@ -1137,6 +1146,7 @@ static int ipslr_status_full(ipslr_handle_t *p, pslr_status *status) {
 // fullpress: take picture
 // halfpress: autofocus
 static int ipslr_press_shutter(ipslr_handle_t *p, bool fullpress) {
+    DPRINT("ipslr_press_shutter(fullpress = %s)\n", (fullpress ? "true" : "false"));
     int r;
     CHECK(ipslr_status_full(p, &p->status));
     DPRINT("before: mask=0x%x\n", p->status.bufmask);
@@ -1166,6 +1176,7 @@ static int ipslr_select_buffer(ipslr_handle_t *p, int bufno, pslr_buffer_type bu
 }
 
 static int ipslr_next_segment(ipslr_handle_t *p) {
+    DPRINT("ipslr_next_segment()\n");
     int r;
     CHECK(ipslr_write_args(p, 1, 0));
     CHECK(command(p->fd, 0x04, 0x01, 0x04));
@@ -1177,6 +1188,7 @@ static int ipslr_next_segment(ipslr_handle_t *p) {
 }
 
 static int ipslr_buffer_segment_info(ipslr_handle_t *p, pslr_buffer_segment_info *pInfo) {
+    DPRINT("ipslr_buffer_segment_info()\n");
     uint8_t buf[16];
     uint32_t n;
     int num_try = 20;
@@ -1189,10 +1201,19 @@ static int ipslr_buffer_segment_info(ipslr_handle_t *p, pslr_buffer_segment_info
             return PSLR_READ_ERROR;
         }
         CHECK(read_result(p->fd, buf, 16));
-        pInfo->a = get_uint32(&buf[0]);
-        pInfo->b = get_uint32(&buf[4]);
-        pInfo->addr = get_uint32(&buf[8]);
-        pInfo->length = get_uint32(&buf[12]);
+
+        //  use the right function based on the endian.
+        get_uint32_func get_uint32_func_ptr;
+        if (p->model->is_little_endian) {
+            get_uint32_func_ptr = get_uint32_le;
+        } else {
+            get_uint32_func_ptr = get_uint32;
+        }
+
+        pInfo->a = (*get_uint32_func_ptr)(&buf[0]);
+        pInfo->b = (*get_uint32_func_ptr)(&buf[4]);
+        pInfo->addr = (*get_uint32_func_ptr)(&buf[8]);
+        pInfo->length = (*get_uint32_func_ptr)(&buf[12]);
 	if( pInfo-> b == 0 ) {
 	  DPRINT("Waiting for segment info addr: 0x%x len: %d B=%d\n", pInfo->addr, pInfo->length, pInfo->b);
 	  sleep_sec( 0.1 );
@@ -1202,6 +1223,7 @@ static int ipslr_buffer_segment_info(ipslr_handle_t *p, pslr_buffer_segment_info
 }
 
 static int ipslr_download(ipslr_handle_t *p, uint32_t addr, uint32_t length, uint8_t *buf) {
+    DPRINT("ipslr_download(address = 0x%x, length = %d)\n", addr, length);
     uint8_t downloadCmd[8] = {0xf0, 0x24, 0x06, 0x02, 0x00, 0x00, 0x00, 0x00};
     uint32_t block;
     int n;
@@ -1243,6 +1265,7 @@ static int ipslr_download(ipslr_handle_t *p, uint32_t addr, uint32_t length, uin
 }
 
 static int ipslr_identify(ipslr_handle_t *p) {
+    DPRINT("ipslr_identify()\n");
     uint8_t idbuf[8];
     int n;
 
@@ -1251,13 +1274,19 @@ static int ipslr_identify(ipslr_handle_t *p) {
     if (n != 8)
         return PSLR_READ_ERROR;
     CHECK(read_result(p->fd, idbuf, 8));
-    p->id = get_uint32(&idbuf[0]);
+    //  Check the camera endian, which affect ID
+    if (idbuf[0] == 0) {
+        p->id = get_uint32(&idbuf[0]);
+    } else {
+        p->id = get_uint32_le(&idbuf[0]);
+    }
     DPRINT("id of the camera: %x\n", p->id);
     p->model = find_model_by_id( p->id );
     return PSLR_OK;
 }
 
 static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
+    DPRINT("_ipslr_write_args(cmd_2 = 0x%x, n = %d)\n", cmd_2, n);
     va_list ap;
     uint8_t cmd[8] = {0xf0, 0x4f, cmd_2, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t buf[4 * n];
@@ -1271,24 +1300,34 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
         /* All at once */
         for (i = 0; i < n; i++) {
             data = va_arg(ap, uint32_t);
-            buf[4 * i + 0] = data >> 24;
-            buf[4 * i + 1] = data >> 16;
-            buf[4 * i + 2] = data >> 8;
-            buf[4 * i + 3] = data;
+
+            //  For some reason, the endian of the args is not as same as model's.
+            if (p->model != NULL && p->model->is_little_endian) {
+                put_uint32_be(data, &buf[4*i]);
+            } else {
+                put_uint32_le(data, &buf[4*i]);
+            }
+
+            hexdump_debug(buf, 4);
         }
         cmd[4] = 4 * n;
+
+
         res = scsi_write(fd, cmd, sizeof (cmd), buf, 4 * n);
         if (res != PSLR_OK) {
             return res;
-	}
+	    }
     } else {
         /* Arguments one by one */
         for (i = 0; i < n; i++) {
             data = va_arg(ap, uint32_t);
-            buf[0] = data >> 24;
-            buf[1] = data >> 16;
-            buf[2] = data >> 8;
-            buf[3] = data;
+
+            if (p->model != NULL && p->model->is_little_endian) {
+                put_uint32_be(data, &buf[0]);
+            } else {
+                put_uint32_le(data, &buf[0]);
+            }
+
             cmd[4] = 4;
             cmd[2] = i * 4;
             res = scsi_write(fd, cmd, sizeof (cmd), buf, 4);
@@ -1309,6 +1348,7 @@ static int command(int fd, int a, int b, int c) {
     cmd[2] = a;
     cmd[3] = b;
     cmd[4] = c;
+
     CHECK(scsi_write(fd, cmd, sizeof (cmd), 0, 0));
     return PSLR_OK;
 }
@@ -1330,15 +1370,17 @@ static int read_status(int fd, uint8_t *buf) {
 
 static int get_status(int fd) {
     uint8_t statusbuf[8];
+    memset(statusbuf,0,8);
+
     while (1) {
         //usleep(POLL_INTERVAL);
         CHECK(read_status(fd, statusbuf));
-        //DPRINT("get_status->\n");
-        //hexdump(statusbuf, 8);
+        // DPRINT("get_status->\n");
+        // hexdump_debug(statusbuf, 8);
         if ((statusbuf[7] & 0x01) == 0)
             break;
         //DPRINT("Waiting for ready - ");
-        //hexdump(statusbuf, 8);
+        //hexdump_debug(statusbuf, 8);
         usleep(POLL_INTERVAL);
     }
     if ((statusbuf[7] & 0xff) != 0) {
@@ -1352,11 +1394,11 @@ static int get_result(int fd) {
     while (1) {
         //DPRINT("read out status\n");
         CHECK(read_status(fd, statusbuf));
-        //hexdump(statusbuf, 8);
+        //hexdump_debug(statusbuf, 8);
         if (statusbuf[6] == 0x01)
             break;
         //DPRINT("Waiting for result\n");
-        //hexdump(statusbuf, 8);
+        //hexdump_debug(statusbuf, 8);
         usleep(POLL_INTERVAL);
     }
     if ((statusbuf[7] & 0xff) != 0) {

--- a/pslr.c
+++ b/pslr.c
@@ -1254,7 +1254,7 @@ static int ipslr_buffer_segment_info(ipslr_handle_t *p, pslr_buffer_segment_info
         if (p->model->is_little_endian) {
             get_uint32_func_ptr = get_uint32_le;
         } else {
-            get_uint32_func_ptr = get_uint32;
+            get_uint32_func_ptr = get_uint32_be;
         }
 
         pInfo->a = (*get_uint32_func_ptr)(&buf[0]);
@@ -1323,7 +1323,7 @@ static int ipslr_identify(ipslr_handle_t *p) {
     CHECK(read_result(p->fd, idbuf, 8));
     //  Check the camera endian, which affect ID
     if (idbuf[0] == 0) {
-        p->id = get_uint32(&idbuf[0]);
+        p->id = get_uint32_be(&idbuf[0]);
     } else {
         p->id = get_uint32_le(&idbuf[0]);
     }
@@ -1359,8 +1359,7 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
         for (i = 0; i < n; i++) {
             data = va_arg(ap, uint32_t);
 
-            //  For some reason, the endian of the args is not as same as model's.
-            if (p->model != NULL && p->model->is_little_endian) {
+            if (p->model == NULL || !p->model->is_little_endian) {
                 set_uint32_be(data, &buf[4*i]);
             } else {
                 set_uint32_le(data, &buf[4*i]);
@@ -1378,7 +1377,7 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
         for (i = 0; i < n; i++) {
             data = va_arg(ap, uint32_t);
 
-            if (p->model != NULL && p->model->is_little_endian) {
+            if (p->model == NULL || !p->model->is_little_endian) {
                 set_uint32_be(data, &buf[0]);
             } else {
                 set_uint32_le(data, &buf[0]);

--- a/pslr_model.c
+++ b/pslr_model.c
@@ -63,19 +63,19 @@ static void ipslr_status_diff(uint8_t *buf) {
     }
 }
 
-uint16_t get_uint16(uint8_t *buf) {
+uint16_t get_uint16_be(uint8_t *buf) {
     uint16_t res;
     res = buf[0] << 8 | buf[1];
     return res;
 }
 
-uint32_t get_uint32(uint8_t *buf) {
+uint32_t get_uint32_be(uint8_t *buf) {
     uint32_t res;
     res = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3];
     return res;
 }
 
-int32_t get_int32(uint8_t *buf) {
+int32_t get_int32_be(uint8_t *buf) {
     int32_t res;
     res = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3];
     return res;
@@ -99,14 +99,14 @@ int32_t get_int32_le(uint8_t *buf) {
     return res;
 }
 
-void set_uint32_be(uint32_t v, uint8_t *buf) {
-    buf[3] = v >> 24;
-    buf[2] = v >> 16;
-    buf[1] = v >> 8;
+void set_uint32_le(uint32_t v, uint8_t *buf) {
     buf[0] = v;
+    buf[1] = v >> 8;
+    buf[2] = v >> 16;
+    buf[3] = v >> 24;
 }
 
-void set_uint32_le(uint32_t v, uint8_t *buf) {
+void set_uint32_be(uint32_t v, uint8_t *buf) {
     buf[0] = v >> 24;
     buf[1] = v >> 16;
     buf[2] = v >> 8;
@@ -186,42 +186,42 @@ void ipslr_status_parse_k10d(ipslr_handle_t  *p, pslr_status *status) {
         ipslr_status_diff(buf);
     }
     memset(status, 0, sizeof (*status));
-    status->bufmask = get_uint16(&buf[0x16]);
-    status->user_mode_flag = get_uint32(&buf[0x1c]);
-    status->set_shutter_speed.nom = get_uint32(&buf[0x2c]);
-    status->set_shutter_speed.denom = get_uint32(&buf[0x30]);
-    status->set_aperture.nom = get_uint32(&buf[0x34]);
-    status->set_aperture.denom = get_uint32(&buf[0x38]);
-    status->ec.nom = get_uint32(&buf[0x3c]);
-    status->ec.denom = get_uint32(&buf[0x40]);
-    status->fixed_iso = get_uint32(&buf[0x60]);
-    status->image_format = get_uint32(&buf[0x78]);
-    status->jpeg_resolution = get_uint32(&buf[0x7c]);
-    status->jpeg_quality = _get_user_jpeg_stars( p->model, get_uint32(&buf[0x80]));
-    status->raw_format = get_uint32(&buf[0x84]);
-    status->jpeg_image_tone = get_uint32(&buf[0x88]);
-    status->jpeg_saturation = get_uint32(&buf[0x8c]);
-    status->jpeg_sharpness = get_uint32(&buf[0x90]);
-    status->jpeg_contrast = get_uint32(&buf[0x94]);
-    status->custom_ev_steps = get_uint32(&buf[0x9c]);
-    status->custom_sensitivity_steps = get_uint32(&buf[0xa0]);
-    status->af_point_select = get_uint32(&buf[0xbc]);
-    status->selected_af_point = get_uint32(&buf[0xc0]);
-    status->exposure_mode = get_uint32(&buf[0xac]);
-    status->current_shutter_speed.nom = get_uint32(&buf[0xf4]);
-    status->current_shutter_speed.denom = get_uint32(&buf[0xf8]);
-    status->current_aperture.nom = get_uint32(&buf[0xfc]);
-    status->current_aperture.denom = get_uint32(&buf[0x100]);
-    status->current_iso = get_uint32(&buf[0x11c]);
-    status->light_meter_flags = get_uint32(&buf[0x124]);
-    status->lens_min_aperture.nom = get_uint32(&buf[0x12c]);
-    status->lens_min_aperture.denom = get_uint32(&buf[0x130]);
-    status->lens_max_aperture.nom = get_uint32(&buf[0x134]);
-    status->lens_max_aperture.denom = get_uint32(&buf[0x138]);
-    status->focused_af_point = get_uint32(&buf[0x150]);
-    status->zoom.nom = get_uint32(&buf[0x16c]);
-    status->zoom.denom = get_uint32(&buf[0x170]);
-    status->focus = get_int32(&buf[0x174]);
+    status->bufmask = get_uint16_be(&buf[0x16]);
+    status->user_mode_flag = get_uint32_be(&buf[0x1c]);
+    status->set_shutter_speed.nom = get_uint32_be(&buf[0x2c]);
+    status->set_shutter_speed.denom = get_uint32_be(&buf[0x30]);
+    status->set_aperture.nom = get_uint32_be(&buf[0x34]);
+    status->set_aperture.denom = get_uint32_be(&buf[0x38]);
+    status->ec.nom = get_uint32_be(&buf[0x3c]);
+    status->ec.denom = get_uint32_be(&buf[0x40]);
+    status->fixed_iso = get_uint32_be(&buf[0x60]);
+    status->image_format = get_uint32_be(&buf[0x78]);
+    status->jpeg_resolution = get_uint32_be(&buf[0x7c]);
+    status->jpeg_quality = _get_user_jpeg_stars( p->model, get_uint32_be(&buf[0x80]));
+    status->raw_format = get_uint32_be(&buf[0x84]);
+    status->jpeg_image_tone = get_uint32_be(&buf[0x88]);
+    status->jpeg_saturation = get_uint32_be(&buf[0x8c]);
+    status->jpeg_sharpness = get_uint32_be(&buf[0x90]);
+    status->jpeg_contrast = get_uint32_be(&buf[0x94]);
+    status->custom_ev_steps = get_uint32_be(&buf[0x9c]);
+    status->custom_sensitivity_steps = get_uint32_be(&buf[0xa0]);
+    status->af_point_select = get_uint32_be(&buf[0xbc]);
+    status->selected_af_point = get_uint32_be(&buf[0xc0]);
+    status->exposure_mode = get_uint32_be(&buf[0xac]);
+    status->current_shutter_speed.nom = get_uint32_be(&buf[0xf4]);
+    status->current_shutter_speed.denom = get_uint32_be(&buf[0xf8]);
+    status->current_aperture.nom = get_uint32_be(&buf[0xfc]);
+    status->current_aperture.denom = get_uint32_be(&buf[0x100]);
+    status->current_iso = get_uint32_be(&buf[0x11c]);
+    status->light_meter_flags = get_uint32_be(&buf[0x124]);
+    status->lens_min_aperture.nom = get_uint32_be(&buf[0x12c]);
+    status->lens_min_aperture.denom = get_uint32_be(&buf[0x130]);
+    status->lens_max_aperture.nom = get_uint32_be(&buf[0x134]);
+    status->lens_max_aperture.denom = get_uint32_be(&buf[0x138]);
+    status->focused_af_point = get_uint32_be(&buf[0x150]);
+    status->zoom.nom = get_uint32_be(&buf[0x16c]);
+    status->zoom.denom = get_uint32_be(&buf[0x170]);
+    status->focus = get_int32_be(&buf[0x174]);
 }
 
 void ipslr_status_parse_k20d(ipslr_handle_t *p, pslr_status *status) {
@@ -231,44 +231,44 @@ void ipslr_status_parse_k20d(ipslr_handle_t *p, pslr_status *status) {
         ipslr_status_diff(buf);
     }
     memset(status, 0, sizeof (*status));
-    status->bufmask = get_uint16( &buf[0x16]);
-    status->user_mode_flag = get_uint32(&buf[0x1c]);
-    status->set_shutter_speed.nom = get_uint32(&buf[0x2c]);
-    status->set_shutter_speed.denom = get_uint32(&buf[0x30]);
-    status->set_aperture.nom = get_uint32(&buf[0x34]);
-    status->set_aperture.denom = get_uint32(&buf[0x38]);
-    status->ec.nom = get_uint32(&buf[0x3c]);
-    status->ec.denom = get_uint32(&buf[0x40]);
-    status->fixed_iso = get_uint32(&buf[0x60]);
-    status->image_format = get_uint32(&buf[0x78]);
-    status->jpeg_resolution = get_uint32(&buf[0x7c]);
-    status->jpeg_quality = _get_user_jpeg_stars( p->model, get_uint32(&buf[0x80]));
-    status->raw_format = get_uint32(&buf[0x84]);
-    status->jpeg_image_tone = get_uint32(&buf[0x88]);
-    status->jpeg_saturation = get_uint32(&buf[0x8c]); // commands do now work for it?
-    status->jpeg_sharpness = get_uint32(&buf[0x90]); // commands do now work for it?
-    status->jpeg_contrast = get_uint32(&buf[0x94]); // commands do now work for it?
-    status->custom_ev_steps = get_uint32(&buf[0x9c]);
-    status->custom_sensitivity_steps = get_uint32(&buf[0xa0]);
-    status->ae_metering_mode = get_uint32(&buf[0xb4]); // same as c4
-    status->af_mode = get_uint32(&buf[0xb8]);
-    status->af_point_select = get_uint32(&buf[0xbc]); // not sure
-    status->selected_af_point = get_uint32(&buf[0xc0]);
-    status->exposure_mode = get_uint32(&buf[0xac]);
-    status->current_shutter_speed.nom = get_uint32(&buf[0x108]);
-    status->current_shutter_speed.denom = get_uint32(&buf[0x10C]);
-    status->current_aperture.nom = get_uint32(&buf[0x110]);
-    status->current_aperture.denom = get_uint32(&buf[0x114]);
-    status->current_iso = get_uint32(&buf[0x130]);
-    status->light_meter_flags = get_uint32(&buf[0x138]);
-    status->lens_min_aperture.nom = get_uint32(&buf[0x140]);
-    status->lens_min_aperture.denom = get_uint32(&buf[0x144]);
-    status->lens_max_aperture.nom = get_uint32(&buf[0x148]);
-    status->lens_max_aperture.denom = get_uint32(&buf[0x14B]);
-    status->focused_af_point = get_uint32(&buf[0x160]); // unsure about it, a lot is changing when the camera focuses
-    status->zoom.nom = get_uint32(&buf[0x180]);
-    status->zoom.denom = get_uint32(&buf[0x184]);
-    status->focus = get_int32(&buf[0x188]); // current focus ring position?
+    status->bufmask = get_uint16_be( &buf[0x16]);
+    status->user_mode_flag = get_uint32_be(&buf[0x1c]);
+    status->set_shutter_speed.nom = get_uint32_be(&buf[0x2c]);
+    status->set_shutter_speed.denom = get_uint32_be(&buf[0x30]);
+    status->set_aperture.nom = get_uint32_be(&buf[0x34]);
+    status->set_aperture.denom = get_uint32_be(&buf[0x38]);
+    status->ec.nom = get_uint32_be(&buf[0x3c]);
+    status->ec.denom = get_uint32_be(&buf[0x40]);
+    status->fixed_iso = get_uint32_be(&buf[0x60]);
+    status->image_format = get_uint32_be(&buf[0x78]);
+    status->jpeg_resolution = get_uint32_be(&buf[0x7c]);
+    status->jpeg_quality = _get_user_jpeg_stars( p->model, get_uint32_be(&buf[0x80]));
+    status->raw_format = get_uint32_be(&buf[0x84]);
+    status->jpeg_image_tone = get_uint32_be(&buf[0x88]);
+    status->jpeg_saturation = get_uint32_be(&buf[0x8c]); // commands do now work for it?
+    status->jpeg_sharpness = get_uint32_be(&buf[0x90]); // commands do now work for it?
+    status->jpeg_contrast = get_uint32_be(&buf[0x94]); // commands do now work for it?
+    status->custom_ev_steps = get_uint32_be(&buf[0x9c]);
+    status->custom_sensitivity_steps = get_uint32_be(&buf[0xa0]);
+    status->ae_metering_mode = get_uint32_be(&buf[0xb4]); // same as c4
+    status->af_mode = get_uint32_be(&buf[0xb8]);
+    status->af_point_select = get_uint32_be(&buf[0xbc]); // not sure
+    status->selected_af_point = get_uint32_be(&buf[0xc0]);
+    status->exposure_mode = get_uint32_be(&buf[0xac]);
+    status->current_shutter_speed.nom = get_uint32_be(&buf[0x108]);
+    status->current_shutter_speed.denom = get_uint32_be(&buf[0x10C]);
+    status->current_aperture.nom = get_uint32_be(&buf[0x110]);
+    status->current_aperture.denom = get_uint32_be(&buf[0x114]);
+    status->current_iso = get_uint32_be(&buf[0x130]);
+    status->light_meter_flags = get_uint32_be(&buf[0x138]);
+    status->lens_min_aperture.nom = get_uint32_be(&buf[0x140]);
+    status->lens_min_aperture.denom = get_uint32_be(&buf[0x144]);
+    status->lens_max_aperture.nom = get_uint32_be(&buf[0x148]);
+    status->lens_max_aperture.denom = get_uint32_be(&buf[0x14B]);
+    status->focused_af_point = get_uint32_be(&buf[0x160]); // unsure about it, a lot is changing when the camera focuses
+    status->zoom.nom = get_uint32_be(&buf[0x180]);
+    status->zoom.denom = get_uint32_be(&buf[0x184]);
+    status->focus = get_int32_be(&buf[0x188]); // current focus ring position?
     // 0x158 current ev?
     // 0x160 and 0x164 change when AF
 }
@@ -278,15 +278,15 @@ void ipslr_status_parse_istds(ipslr_handle_t *p, pslr_status *status) {
     uint8_t *buf = p->status_buffer;
     /* *ist DS status block */
     memset(status, 0, sizeof (*status));
-    status->bufmask = get_uint16(&buf[0x12]);
-    status->set_shutter_speed.nom = get_uint32(&buf[0x80]);
-    status->set_shutter_speed.denom = get_uint32(&buf[0x84]);
-    status->set_aperture.nom = get_uint32(&buf[0x88]);
-    status->set_aperture.denom = get_uint32(&buf[0x8c]);
-    status->lens_min_aperture.nom = get_uint32(&buf[0xb8]);
-    status->lens_min_aperture.denom = get_uint32(&buf[0xbc]);
-    status->lens_max_aperture.nom = get_uint32(&buf[0xc0]);
-    status->lens_max_aperture.denom = get_uint32(&buf[0xc4]);
+    status->bufmask = get_uint16_be(&buf[0x12]);
+    status->set_shutter_speed.nom = get_uint32_be(&buf[0x80]);
+    status->set_shutter_speed.denom = get_uint32_be(&buf[0x84]);
+    status->set_aperture.nom = get_uint32_be(&buf[0x88]);
+    status->set_aperture.denom = get_uint32_be(&buf[0x8c]);
+    status->lens_min_aperture.nom = get_uint32_be(&buf[0xb8]);
+    status->lens_min_aperture.denom = get_uint32_be(&buf[0xbc]);
+    status->lens_max_aperture.nom = get_uint32_be(&buf[0xc0]);
+    status->lens_max_aperture.denom = get_uint32_be(&buf[0xc4]);
 
     // no DNG support so raw format is PEF
     status->raw_format = PSLR_RAW_FORMAT_PEF;
@@ -308,9 +308,9 @@ void ipslr_status_parse_common(ipslr_handle_t *p, pslr_status *status, int shift
         get_int32_func_ptr = get_int32_le;
         get_uint16_func_ptr = get_uint16_le;
     } else {
-        get_uint32_func_ptr = get_uint32;
-        get_int32_func_ptr = get_int32;
-        get_uint16_func_ptr = get_uint16;
+        get_uint32_func_ptr = get_uint32_be;
+        get_int32_func_ptr = get_int32_be;
+        get_uint16_func_ptr = get_uint16_be;
     }
 
     // 0x0C: 0x85 0xA5
@@ -388,11 +388,11 @@ void ipslr_status_parse_kx(ipslr_handle_t *p, pslr_status *status) {
 
     memset(status, 0, sizeof (*status));
     ipslr_status_parse_common( p, status, 0);
-    status->zoom.nom = get_uint32(&buf[0x198]);
-    status->zoom.denom = get_uint32(&buf[0x19C]);
-    status->focus = get_int32(&buf[0x1A0]);
-    status->lens_id1 = (get_uint32( &buf[0x188])) & 0x0F;
-    status->lens_id2 = get_uint32( &buf[0x194]);
+    status->zoom.nom = get_uint32_be(&buf[0x198]);
+    status->zoom.denom = get_uint32_be(&buf[0x19C]);
+    status->focus = get_int32_be(&buf[0x1A0]);
+    status->lens_id1 = (get_uint32_be( &buf[0x188])) & 0x0F;
+    status->lens_id2 = get_uint32_be( &buf[0x194]);
 }
 
 // Vince: K-r support 2011-06-22
@@ -405,11 +405,11 @@ void ipslr_status_parse_kr(ipslr_handle_t *p, pslr_status *status) {
 
     memset(status, 0, sizeof (*status));
     ipslr_status_parse_common( p, status, 0 );
-    status->zoom.nom = get_uint32(&buf[0x19C]);
-    status->zoom.denom = get_uint32(&buf[0x1A0]);
-    status->focus = get_int32(&buf[0x1A4]);
-    status->lens_id1 = (get_uint32( &buf[0x18C])) & 0x0F;
-    status->lens_id2 = get_uint32( &buf[0x198]);
+    status->zoom.nom = get_uint32_be(&buf[0x19C]);
+    status->zoom.denom = get_uint32_be(&buf[0x1A0]);
+    status->focus = get_int32_be(&buf[0x1A4]);
+    status->lens_id1 = (get_uint32_be( &buf[0x18C])) & 0x0F;
+    status->lens_id2 = get_uint32_be( &buf[0x198]);
 }
 
 void ipslr_status_parse_k5(ipslr_handle_t *p, pslr_status *status) {
@@ -420,11 +420,11 @@ void ipslr_status_parse_k5(ipslr_handle_t *p, pslr_status *status) {
 
     memset(status, 0, sizeof (*status));
     ipslr_status_parse_common( p, status, 0 );
-    status->zoom.nom = get_uint32(&buf[0x1A0]);
-    status->zoom.denom = get_uint32(&buf[0x1A4]);
-    status->focus = get_int32(&buf[0x1A8]); // ?
-    status->lens_id1 = (get_uint32( &buf[0x190])) & 0x0F;
-    status->lens_id2 = get_uint32( &buf[0x19C]);
+    status->zoom.nom = get_uint32_be(&buf[0x1A0]);
+    status->zoom.denom = get_uint32_be(&buf[0x1A4]);
+    status->focus = get_int32_be(&buf[0x1A8]); // ?
+    status->lens_id1 = (get_uint32_be( &buf[0x190])) & 0x0F;
+    status->lens_id2 = get_uint32_be( &buf[0x19C]);
 
 // TODO: check these fields
 //status.focused = getInt32(statusBuf, 0x164);
@@ -442,11 +442,11 @@ void ipslr_status_parse_k30(ipslr_handle_t *p, pslr_status *status) {
     //~ status->jpeg_hue -= 4;
     //~ status->jpeg_sharpness -= 4;
     //~ status->jpeg_saturation -= 4;
-    status->zoom.nom = get_uint32(&buf[0x1A0]);
+    status->zoom.nom = get_uint32_be(&buf[0x1A0]);
     status->zoom.denom = 100;
-    status->focus = get_int32(&buf[0x1A8]); // ?
-    status->lens_id1 = (get_uint32( &buf[0x190])) & 0x0F;
-    status->lens_id2 = get_uint32( &buf[0x19C]);
+    status->focus = get_int32_be(&buf[0x1A8]); // ?
+    status->lens_id1 = (get_uint32_be( &buf[0x190])) & 0x0F;
+    status->lens_id2 = get_uint32_be( &buf[0x19C]);
 }
 
 // status check seems to be the same as K30
@@ -462,11 +462,11 @@ void ipslr_status_parse_k01(ipslr_handle_t *p, pslr_status *status) {
     //~ status->jpeg_hue -= 4;
     //~ status->jpeg_sharpness -= 4;
     //~ status->jpeg_saturation -= 4;
-    status->zoom.nom = get_uint32(&buf[0x1A0]); // - good for K01
+    status->zoom.nom = get_uint32_be(&buf[0x1A0]); // - good for K01
     status->zoom.denom = 100; // good for K-01
-    status->focus = get_int32(&buf[0x1A8]); // ? - good for K01
-    status->lens_id1 = (get_uint32( &buf[0x190])) & 0x0F; // - good for K01
-    status->lens_id2 = get_uint32( &buf[0x19C]); // - good for K01
+    status->focus = get_int32_be(&buf[0x1A8]); // ? - good for K01
+    status->lens_id1 = (get_uint32_be( &buf[0x190])) & 0x0F; // - good for K01
+    status->lens_id2 = get_uint32_be( &buf[0x19C]); // - good for K01
 }
 
 void ipslr_status_parse_k50(ipslr_handle_t *p, pslr_status *status) {
@@ -477,11 +477,11 @@ void ipslr_status_parse_k50(ipslr_handle_t *p, pslr_status *status) {
 
     memset(status, 0, sizeof (*status));
     ipslr_status_parse_common( p, status, 0 );
-    status->zoom.nom = get_uint32(&buf[0x1A0]);
-    status->zoom.denom = get_uint32(&buf[0x1A4]);
-    //    status->focus = get_int32(&buf[0x1A8]); // ?
-    status->lens_id1 = (get_uint32( &buf[0x190])) & 0x0F;
-    status->lens_id2 = get_uint32( &buf[0x19C]);
+    status->zoom.nom = get_uint32_be(&buf[0x1A0]);
+    status->zoom.denom = get_uint32_be(&buf[0x1A4]);
+    //    status->focus = get_int32_be(&buf[0x1A8]); // ?
+    status->lens_id1 = (get_uint32_be( &buf[0x190])) & 0x0F;
+    status->lens_id2 = get_uint32_be( &buf[0x19C]);
 }
 
 
@@ -493,10 +493,10 @@ void ipslr_status_parse_km(ipslr_handle_t *p, pslr_status *status) {
 
     memset(status, 0, sizeof (*status));
     ipslr_status_parse_common( p, status, -4);
-    status->zoom.nom = get_uint32(&buf[0x180]);
-    status->zoom.denom = get_uint32(&buf[0x184]);
-    status->lens_id1 = (get_uint32( &buf[0x170])) & 0x0F;
-    status->lens_id2 = get_uint32( &buf[0x17c]);
+    status->zoom.nom = get_uint32_be(&buf[0x180]);
+    status->zoom.denom = get_uint32_be(&buf[0x184]);
+    status->lens_id1 = (get_uint32_be( &buf[0x170])) & 0x0F;
+    status->lens_id2 = get_uint32_be( &buf[0x17c]);
 // TODO
 // status.focused = getInt32(statusBuf, 0x164);
 }
@@ -525,48 +525,48 @@ void ipslr_status_parse_k200d(ipslr_handle_t *p, pslr_status *status) {
     }
 
     memset(status, 0, sizeof (*status));
-    status->bufmask = get_uint16(&buf[0x16]);
-    status->user_mode_flag = get_uint32(&buf[0x1c]);
-    status->set_shutter_speed.nom = get_uint32(&buf[0x2c]);
-    status->set_shutter_speed.denom = get_uint32(&buf[0x30]);
-    status->current_aperture.nom = get_uint32(&buf[0x034]);
-    status->current_aperture.denom = get_uint32(&buf[0x038]);
-    status->set_aperture.nom = get_uint32(&buf[0x34]);
-    status->set_aperture.denom = get_uint32(&buf[0x38]);
-    status->ec.nom = get_uint32(&buf[0x3c]);
-    status->ec.denom = get_uint32(&buf[0x40]);
-    status->current_iso = get_uint32(&buf[0x060]);
-    status->fixed_iso = get_uint32(&buf[0x60]);
-    status->auto_iso_min = get_uint32(&buf[0x64]);
-    status->auto_iso_max = get_uint32(&buf[0x68]);
-    status->image_format = get_uint32(&buf[0x78]);
-    status->jpeg_resolution = get_uint32(&buf[0x7c]);
-    status->jpeg_quality = _get_user_jpeg_stars( p->model, get_uint32(&buf[0x80]));
-    status->raw_format = get_uint32(&buf[0x84]);
-    status->jpeg_image_tone = get_uint32(&buf[0x88]);
-    status->jpeg_saturation = get_uint32(&buf[0x8c]);
-    status->jpeg_sharpness = get_uint32(&buf[0x90]);
-    status->jpeg_contrast = get_uint32(&buf[0x94]);
-    //status->custom_ev_steps = get_uint32(&buf[0x9c]);
-    //status->custom_sensitivity_steps = get_uint32(&buf[0xa0]);
-    status->exposure_mode = get_uint32(&buf[0xac]);
-    status->af_mode = get_uint32(&buf[0xb8]);
-    status->af_point_select = get_uint32(&buf[0xbc]);
-    status->selected_af_point = get_uint32(&buf[0xc0]);
-    status->drive_mode = get_uint32(&buf[0xcc]);
-    status->shake_reduction = get_uint32(&buf[0xda]);
-    status->jpeg_hue = get_uint32(&buf[0xf4]);
-    status->current_shutter_speed.nom = get_uint32(&buf[0x0104]);
-    status->current_shutter_speed.denom = get_uint32(&buf[0x108]);
-    status->light_meter_flags = get_uint32(&buf[0x124]);
-    status->lens_min_aperture.nom = get_uint32(&buf[0x13c]);
-    status->lens_min_aperture.denom = get_uint32(&buf[0x140]);
-    status->lens_max_aperture.nom = get_uint32(&buf[0x144]);
-    status->lens_max_aperture.denom = get_uint32(&buf[0x148]);
-    status->focused_af_point = get_uint32(&buf[0x150]);
-    status->zoom.nom = get_uint32(&buf[0x17c]);
-    status->zoom.denom = get_uint32(&buf[0x180]);
-    status->focus = get_int32(&buf[0x184]);
+    status->bufmask = get_uint16_be(&buf[0x16]);
+    status->user_mode_flag = get_uint32_be(&buf[0x1c]);
+    status->set_shutter_speed.nom = get_uint32_be(&buf[0x2c]);
+    status->set_shutter_speed.denom = get_uint32_be(&buf[0x30]);
+    status->current_aperture.nom = get_uint32_be(&buf[0x034]);
+    status->current_aperture.denom = get_uint32_be(&buf[0x038]);
+    status->set_aperture.nom = get_uint32_be(&buf[0x34]);
+    status->set_aperture.denom = get_uint32_be(&buf[0x38]);
+    status->ec.nom = get_uint32_be(&buf[0x3c]);
+    status->ec.denom = get_uint32_be(&buf[0x40]);
+    status->current_iso = get_uint32_be(&buf[0x060]);
+    status->fixed_iso = get_uint32_be(&buf[0x60]);
+    status->auto_iso_min = get_uint32_be(&buf[0x64]);
+    status->auto_iso_max = get_uint32_be(&buf[0x68]);
+    status->image_format = get_uint32_be(&buf[0x78]);
+    status->jpeg_resolution = get_uint32_be(&buf[0x7c]);
+    status->jpeg_quality = _get_user_jpeg_stars( p->model, get_uint32_be(&buf[0x80]));
+    status->raw_format = get_uint32_be(&buf[0x84]);
+    status->jpeg_image_tone = get_uint32_be(&buf[0x88]);
+    status->jpeg_saturation = get_uint32_be(&buf[0x8c]);
+    status->jpeg_sharpness = get_uint32_be(&buf[0x90]);
+    status->jpeg_contrast = get_uint32_be(&buf[0x94]);
+    //status->custom_ev_steps = get_uint32_be(&buf[0x9c]);
+    //status->custom_sensitivity_steps = get_uint32_be(&buf[0xa0]);
+    status->exposure_mode = get_uint32_be(&buf[0xac]);
+    status->af_mode = get_uint32_be(&buf[0xb8]);
+    status->af_point_select = get_uint32_be(&buf[0xbc]);
+    status->selected_af_point = get_uint32_be(&buf[0xc0]);
+    status->drive_mode = get_uint32_be(&buf[0xcc]);
+    status->shake_reduction = get_uint32_be(&buf[0xda]);
+    status->jpeg_hue = get_uint32_be(&buf[0xf4]);
+    status->current_shutter_speed.nom = get_uint32_be(&buf[0x0104]);
+    status->current_shutter_speed.denom = get_uint32_be(&buf[0x108]);
+    status->light_meter_flags = get_uint32_be(&buf[0x124]);
+    status->lens_min_aperture.nom = get_uint32_be(&buf[0x13c]);
+    status->lens_min_aperture.denom = get_uint32_be(&buf[0x140]);
+    status->lens_max_aperture.nom = get_uint32_be(&buf[0x144]);
+    status->lens_max_aperture.denom = get_uint32_be(&buf[0x148]);
+    status->focused_af_point = get_uint32_be(&buf[0x150]);
+    status->zoom.nom = get_uint32_be(&buf[0x17c]);
+    status->zoom.denom = get_uint32_be(&buf[0x180]);
+    status->focus = get_int32_be(&buf[0x184]);
     // Drive mode: 0=Single shot, 1= Continous Hi, 2= Continous Low or Self timer 12s, 3=Self timer 2s
     // 4= remote, 5= remote 3s delay
 }

--- a/pslr_model.c
+++ b/pslr_model.c
@@ -99,14 +99,14 @@ int32_t get_int32_le(uint8_t *buf) {
     return res;
 }
 
-void put_uint32_be(uint32_t v, uint8_t *buf) {
+void set_uint32_be(uint32_t v, uint8_t *buf) {
     buf[3] = v >> 24;
     buf[2] = v >> 16;
     buf[1] = v >> 8;
     buf[0] = v;
 }
 
-void put_uint32_le(uint32_t v, uint8_t *buf) {
+void set_uint32_le(uint32_t v, uint8_t *buf) {
     buf[0] = v >> 24;
     buf[1] = v >> 16;
     buf[2] = v >> 8;
@@ -512,7 +512,7 @@ void ipslr_status_parse_k3(ipslr_handle_t *p, pslr_status *status) {
     ipslr_status_parse_common( p, status, 0 );
     status->bufmask = get_uint16_le( &buf[0x1C]);
     status->zoom.nom = get_uint32_le(&buf[0x1A0]);
-    status->zoom.denom = 100;
+    status->zoom.denom = get_uint32_le(&buf[0x1A4]);
     status->focus = get_int32_le(&buf[0x1A8]);
     status->lens_id1 = (get_uint32_le( &buf[0x190])) & 0x0F;
     status->lens_id2 = get_uint32_le( &buf[0x19C]);

--- a/pslr_model.c
+++ b/pslr_model.c
@@ -53,7 +53,7 @@ static void ipslr_status_diff(uint8_t *buf) {
     diffs = 0;
     for (n = 0; n < MAX_STATUS_BUF_SIZE; n++) {
         if (lastbuf[n] != buf[n]) {
-            DPRINT("buf[%03X] last %02Xh %3d new %02Xh %3d\n", n, lastbuf[n], lastbuf[n], buf[n], buf[n]);
+            DPRINT("\t\tbuf[%03X] last %02Xh %3d new %02Xh %3d\n", n, lastbuf[n], lastbuf[n], buf[n], buf[n]);
             diffs++;
         }
     }

--- a/pslr_model.h
+++ b/pslr_model.h
@@ -149,8 +149,8 @@ int get_hw_jpeg_quality( ipslr_model_info_t *model, int user_jpeg_stars);
 
 uint32_t get_uint32(uint8_t *buf);
 uint32_t get_uint32_le(uint8_t *buf);
-void put_uint32_be(uint32_t v, uint8_t *buf);
-void put_uint32_le(uint32_t v, uint8_t *buf);
+void set_uint32_be(uint32_t v, uint8_t *buf);
+void set_uint32_le(uint32_t v, uint8_t *buf);
 
 typedef uint32_t (*get_uint32_func)(uint8_t *buf);
 typedef uint16_t (*get_uint16_func)(uint8_t *buf);

--- a/pslr_model.h
+++ b/pslr_model.h
@@ -147,7 +147,7 @@ ipslr_model_info_t *find_model_by_id( uint32_t id );
 
 int get_hw_jpeg_quality( ipslr_model_info_t *model, int user_jpeg_stars);
 
-uint32_t get_uint32(uint8_t *buf);
+uint32_t get_uint32_be(uint8_t *buf);
 uint32_t get_uint32_le(uint8_t *buf);
 void set_uint32_be(uint32_t v, uint8_t *buf);
 void set_uint32_le(uint32_t v, uint8_t *buf);

--- a/pslr_model.h
+++ b/pslr_model.h
@@ -18,7 +18,7 @@
     Copyright (C) 2010 Tomasz Kos
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by 
+    it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
@@ -111,6 +111,7 @@ typedef struct {
     const char *name;                                // name
     bool old_scsi_command;                           // 1 for *ist cameras, 0 for the newer cameras
     bool need_exposure_mode_conversion;              // is exposure_mode_conversion required
+    bool is_little_endian;                           // whether the return value should be parsed as little-endian
     int buffer_size;                                 // buffer size in bytes
     int max_jpeg_stars;                              // maximum jpeg stars
     int jpeg_resolutions[MAX_RESOLUTION_SIZE];       // jpeg resolution table
@@ -147,7 +148,15 @@ ipslr_model_info_t *find_model_by_id( uint32_t id );
 int get_hw_jpeg_quality( ipslr_model_info_t *model, int user_jpeg_stars);
 
 uint32_t get_uint32(uint8_t *buf);
+uint32_t get_uint32_le(uint8_t *buf);
+void put_uint32_be(uint32_t v, uint8_t *buf);
+void put_uint32_le(uint32_t v, uint8_t *buf);
+
+typedef uint32_t (*get_uint32_func)(uint8_t *buf);
+typedef uint16_t (*get_uint16_func)(uint8_t *buf);
+typedef int32_t (*get_int32_func)(uint8_t *buf);
 
 void hexdump(uint8_t *buf, uint32_t bufLen);
+void hexdump_debug(uint8_t *buf, uint32_t bufLen);
 
 #endif

--- a/pslr_scsi_linux.c
+++ b/pslr_scsi_linux.c
@@ -167,6 +167,18 @@ int scsi_read(int sg_fd, uint8_t *cmd, uint32_t cmdLen,
     /* io.pack_id = 0; */
     /* io.usr_ptr = NULL; */
 
+    DPRINT("[S]\t\t\t\t\t >>> [");
+    for (i = 0; i < cmdLen; ++i) {
+        if (i > 0) {
+            DPRINT(" ");
+            if ((i%4) == 0 ) {
+                DPRINT(" ");
+            }
+        }
+        DPRINT("%02X", cmd[i]);
+    }
+    DPRINT("]\n");
+
     r = ioctl(sg_fd, SG_IO, &io);
     if (r == -1) {
         perror("ioctl");
@@ -177,17 +189,6 @@ int scsi_read(int sg_fd, uint8_t *cmd, uint32_t cmdLen,
         print_scsi_error(&io, sense);
         return -PSLR_SCSI_ERROR;
     } else {
-        DPRINT("[S]\t\t\t\t\t >>> [");
-        for (i = 0; i < cmdLen; ++i) {
-            if (i > 0) {
-                DPRINT(" ");
-                if ((i%4) == 0 ) {
-                    DPRINT(" ");
-                }
-            }
-            DPRINT("%02X", cmd[i]);
-        }
-        DPRINT("]\n");
         DPRINT("[S]\t\t\t\t\t <<< [");
         for (i = 0; i < 32 && i < (bufLen - io.resid); ++i) {
             if (i > 0) {
@@ -235,6 +236,35 @@ int scsi_write(int sg_fd, uint8_t *cmd, uint32_t cmdLen,
     /* io.pack_id = 0; */
     /* io.usr_ptr = NULL; */
 
+    //  print debug scsi cmd
+    DPRINT("[S]\t\t\t\t\t >>> [");
+    for (i = 0; i < cmdLen; ++i) {
+        if (i > 0) {
+            DPRINT(" ");
+            if ((i%4) == 0 ) {
+                DPRINT(" ");
+            }
+        }
+        DPRINT("%02X", cmd[i]);
+    }
+    DPRINT("]\n");
+    if (bufLen > 0) {
+        //  print debug write buffer
+        DPRINT("[S]\t\t\t\t\t >>> [");
+        for (i = 0; i < 32 && i < bufLen; ++i) {
+            if (i > 0) {
+                DPRINT(" ");
+                if (i % 16 == 0) {
+                    DPRINT("\n\t\t\t\t\t      ");
+                } else if ((i%4) == 0 ) {
+                    DPRINT(" ");
+                }
+            }
+            DPRINT("%02X", buf[i]);
+        }
+        DPRINT("]\n");
+    }
+
     r = ioctl(sg_fd, SG_IO, &io);
 
     if (r == -1) {
@@ -246,32 +276,6 @@ int scsi_write(int sg_fd, uint8_t *cmd, uint32_t cmdLen,
         print_scsi_error(&io, sense);
         return PSLR_SCSI_ERROR;
     } else {
-        DPRINT("[S]\t\t\t\t\t >>> [");
-        for (i = 0; i < cmdLen; ++i) {
-            if (i > 0) {
-                DPRINT(" ");
-                if ((i%4) == 0 ) {
-                    DPRINT(" ");
-                }
-            }
-            DPRINT("%02X", cmd[i]);
-        }
-        DPRINT("]\n");
-        if (bufLen > 0) {
-            DPRINT("[S]\t\t\t\t\t >>> [");
-            for (i = 0; i < 32 && i < bufLen; ++i) {
-                if (i > 0) {
-                    DPRINT(" ");
-                    if (i % 16 == 0) {
-                        DPRINT("\n\t\t\t\t\t      ");
-                    } else if ((i%4) == 0 ) {
-                        DPRINT(" ");
-                    }
-                }
-                DPRINT("%02X", buf[i]);
-            }
-            DPRINT("]\n");
-        }
         return PSLR_OK;
     }
 }


### PR DESCRIPTION
This is the K-3 support codes I did so far.

Currently the X10_BULB, X10_CONTINOUS, X10_GREEN are not working on K-3. I haven't got any progress recently. To make them work, I believe I need do some reverse engineering work on the K-3 firmware (or maybe Flucard firmware as well), which I hope I can find anything useful, but as it's not an easy job, may take some time to dig.

In the meantime, I think we should merge my 'k3' branch to the 'master' for now. So, at least it works for K-3/K-3 II, if not using above functions.
