### PR TITLE
Adding K-S1 and K-S2 support (Experimental)

### DIFF
--- a/pslr_model.c
+++ b/pslr_model.c
@@ -601,6 +601,8 @@ ipslr_model_info_t camera_models[] = {
     { 0x12b9d, "K110D",       0, 1, 0, 0,   3, {6, 4, 2}, 5, 4000, 200, 3200, 200, 3200, PSLR_JPEG_IMAGE_TONE_BRIGHT, 0, NULL},
     { 0x12b9c, "K100D",       1, 1, 0, 0,   3, {6, 4, 2}, 5, 4000, 200, 3200, 200, 3200, PSLR_JPEG_IMAGE_TONE_BRIGHT, 0, NULL},
     { 0x12ba2, "K100D Super", 1, 1, 0, 0,   3, {6, 4, 2}, 5, 4000, 200, 3200, 200, 3200, PSLR_JPEG_IMAGE_TONE_BRIGHT, 0, NULL},
+    { 0x1301a, "K-S1",        0, 1, 1, 452,  3, {20, 12, 6, 2}, 9, 6000, 100, 51200, 100, 51200, PSLR_JPEG_IMAGE_TONE_BLEACH_BYPASS, 1, ipslr_status_parse_k3    },
+    { 0x13024, "K-S2",        0, 1, 1, 452,  3, {20, 12, 6, 2}, 9, 6000, 100, 51200, 100, 51200, PSLR_JPEG_IMAGE_TONE_BLEACH_BYPASS, 1, ipslr_status_parse_k3    },
 };
 
 ipslr_model_info_t *find_model_by_id( uint32_t id ) {


### PR DESCRIPTION
I added `K-S1` and `K-S2` id to `pslr_model.c`, based on current understanding, I think K-S1 or K-S2 are similar to K-3's implementation, I didn't test it, but we can put it in the code, so maybe someone with the camera can test it later.
