### PR TITLE
Fixes for k70

### DIFF
--- a/pktriggercord-cli.c
+++ b/pktriggercord-cli.c
@@ -514,6 +514,7 @@ int main(int argc, char **argv) {
 	    case 24:
 		modify_debug_mode=1;
 		debug_mode=atoi(optarg);
+		break;
 
             case 25:
                 dangerous = true;

--- a/pslr_model.c
+++ b/pslr_model.c
@@ -612,6 +612,7 @@ void ipslr_status_parse_k70(ipslr_handle_t *p, pslr_status *status) {
 //    status->focus = get_int32_le(&buf[0x1A8]);
     status->lens_id1 = (get_uint32_le( &buf[0x194])) & 0x0F;
     status->lens_id2 = get_uint32_le( &buf[0x1A0]);
+    status->shake_reduction = get_uint32_be(&buf[0xe4]);
 }
 
 void ipslr_status_parse_k200d(ipslr_handle_t *p, pslr_status *status) {


### PR DESCRIPTION
Small fixes:
- Correct buffer address for shake reduction setting
- Add (very likely) missing break statement in the handling of the command line options