### PR TITLE
Also do Windows cross-compilation build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,35 @@ android:
     - platform-tools
     - build-tools-23.0.1
     - android-12
+addons:
+  apt:
+    packages:
+    - binutils-mingw-w64-i686
+    - mingw-w64-dev
+    - g++-mingw-w64-i686
+    - gcc-mingw-w64-i686
+    - wine
 before_install:
   - make
   - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root
   - export ANDROID_NDK_HOME=$HOME/android-ndk-root
+before_script:
+  mkdir -p i686-w64-mingw32
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+_2.24.10-1_win32.zip
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-dev_2.24.10-1_win32.zip
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/glib/2.28/glib-dev_2.28.8-1_win32.zip
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/atk/1.32/atk-dev_1.32.0-2_win32.zip
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/pango/1.29/pango-dev_1.29.4-1_win32.zip
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gdk-pixbuf/2.24/gdk-pixbuf-dev_2.24.0-1_win32.zip
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gdk-pixbuf/2.24/gdk-pixbuf_2.24.0-1_win32.zip
+  wget http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/cairo-dev_1.10.2-2_win32.zip
+  cd i686-w64-mingw32
+  unzip ../gtk+_2.24.10-1_win32.zip
+  unzip ../gtk+-dev_2.24.10-1_win32.zip
+  unzip ../glib-dev_2.28.8-1_win32.zip
+  unzip ../atk-dev_1.32.0-2_win32.zip
+  unzip ../pango-dev_1.29.4-1_win32.zip
+  unzip ../gdk-pixbuf-dev_2.24.0-1_win32.zip
+  unzip ../gdk-pixbuf_2.24.0-1_win32.zip
+  unzip ../cairo-dev_1.10.2-2_win32.zip
 script: make android

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     - g++-mingw-w64-i686
     - gcc-mingw-w64-i686
     - wine
+    - groff
 before_install:
   - make
   - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
   - ./pktriggercord-cli --help
   - mkdir -p windows_test
   - cd windows_test
-  - ../unzip pktriggercord-*-win.zip
+  - unzip ../pktriggercord-*-win.zip
   - wine ./pktriggercord-cli.exe --help
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ addons:
     - wine
     - groff
 before_install:
-  - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1
-  - export ANDROID_NDK_HOME=$HOME/android-ndk-root
+#  - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1
+#  - export ANDROID_NDK_HOME=$HOME/android-ndk-root
 before_script:
   - mkdir -p i686-w64-mingw32
   - wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+_2.24.10-1_win32.zip
@@ -35,16 +35,15 @@ before_script:
   - unzip ../gdk-pixbuf-dev_2.24.0-1_win32.zip
   - unzip ../gdk-pixbuf_2.24.0-1_win32.zip
   - unzip ../cairo-dev_1.10.2-2_win32.zip
-  - ls -lR
   - cd ..
 script:
-  - make android
+#  - make android
   - make WINMINGW=i686-w64-mingw32 win
   - make clean
   - make
-  - ./pktriggercord-cli --help
+  - ./pktriggercord-cli --version
   - mkdir -p windows_test
   - cd windows_test
   - unzip ../pktriggercord-*-win.zip
-  - wine ./pktriggercord-cli.exe --help
+  - wine ./pktriggercord-cli.exe --version
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ addons:
     - wine
     - groff
 before_install:
-#  - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1
-#  - export ANDROID_NDK_HOME=$HOME/android-ndk-root
+  - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1
+  - export ANDROID_NDK_HOME=$HOME/android-ndk-root
 before_script:
   - mkdir -p i686-w64-mingw32
   - wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+_2.24.10-1_win32.zip
@@ -37,7 +37,7 @@ before_script:
   - unzip ../cairo-dev_1.10.2-2_win32.zip
   - cd ..
 script:
-#  - make android
+  - make android
   - make WINMINGW=i686-w64-mingw32 win
   - make clean
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,11 @@ before_script:
 script:
   - make android
   - make WINMINGW=i686-w64-mingw32 win
+  - make clean
   - make
+  - ./pktriggercord-cli --help
   - mkdir -p windows_test
   - cd windows_test
   - ../unzip pktriggercord-*-win.zip
   - wine ./pktriggercord-cli.exe --help
   - cd ..
-  - ./pktriggercord-cli --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
     - wine
     - groff
 before_install:
-  - make
   - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1
   - export ANDROID_NDK_HOME=$HOME/android-ndk-root
 before_script:
@@ -41,3 +40,10 @@ before_script:
 script:
   - make android
   - make WINMINGW=i686-w64-mingw32 win
+  - make
+  - mkdir -p windows_test
+  - cd windows_test
+  - ../unzip pktriggercord-*-win.zip
+  - wine ./pktriggercord-cli.exe --help
+  - cd ..
+  - ./pktriggercord-cli --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
   apt:
     packages:
     - binutils-mingw-w64-i686
-    - mingw-w64-dev
     - g++-mingw-w64-i686
     - gcc-mingw-w64-i686
     - wine
@@ -36,7 +35,8 @@ before_script:
   unzip ../gdk-pixbuf-dev_2.24.0-1_win32.zip
   unzip ../gdk-pixbuf_2.24.0-1_win32.zip
   unzip ../cairo-dev_1.10.2-2_win32.zip
+  ls -lR
   cd ..
 script:
-  make android
-  make WINMINGW=i686-w64-mingw32 win
+  - make android
+  - make WINMINGW=i686-w64-mingw32 win

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
     - wine
 before_install:
   - make
-  - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root
+  - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1
   - export ANDROID_NDK_HOME=$HOME/android-ndk-root
 before_script:
   mkdir -p i686-w64-mingw32
@@ -36,4 +36,7 @@ before_script:
   unzip ../gdk-pixbuf-dev_2.24.0-1_win32.zip
   unzip ../gdk-pixbuf_2.24.0-1_win32.zip
   unzip ../cairo-dev_1.10.2-2_win32.zip
-script: make android
+  cd ..
+script:
+  make android
+  make WINMINGW=i686-w64-mingw32 win

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,26 +17,26 @@ before_install:
   - git clone https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root --depth 1
   - export ANDROID_NDK_HOME=$HOME/android-ndk-root
 before_script:
-  mkdir -p i686-w64-mingw32
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+_2.24.10-1_win32.zip
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-dev_2.24.10-1_win32.zip
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/glib/2.28/glib-dev_2.28.8-1_win32.zip
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/atk/1.32/atk-dev_1.32.0-2_win32.zip
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/pango/1.29/pango-dev_1.29.4-1_win32.zip
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gdk-pixbuf/2.24/gdk-pixbuf-dev_2.24.0-1_win32.zip
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/gdk-pixbuf/2.24/gdk-pixbuf_2.24.0-1_win32.zip
-  wget http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/cairo-dev_1.10.2-2_win32.zip
-  cd i686-w64-mingw32
-  unzip ../gtk+_2.24.10-1_win32.zip
-  unzip ../gtk+-dev_2.24.10-1_win32.zip
-  unzip ../glib-dev_2.28.8-1_win32.zip
-  unzip ../atk-dev_1.32.0-2_win32.zip
-  unzip ../pango-dev_1.29.4-1_win32.zip
-  unzip ../gdk-pixbuf-dev_2.24.0-1_win32.zip
-  unzip ../gdk-pixbuf_2.24.0-1_win32.zip
-  unzip ../cairo-dev_1.10.2-2_win32.zip
-  ls -lR
-  cd ..
+  - mkdir -p i686-w64-mingw32
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+_2.24.10-1_win32.zip
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-dev_2.24.10-1_win32.zip
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/glib/2.28/glib-dev_2.28.8-1_win32.zip
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/atk/1.32/atk-dev_1.32.0-2_win32.zip
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/pango/1.29/pango-dev_1.29.4-1_win32.zip
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/gdk-pixbuf/2.24/gdk-pixbuf-dev_2.24.0-1_win32.zip
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/gdk-pixbuf/2.24/gdk-pixbuf_2.24.0-1_win32.zip
+  - wget http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/cairo-dev_1.10.2-2_win32.zip
+  - cd i686-w64-mingw32
+  - unzip ../gtk+_2.24.10-1_win32.zip
+  - unzip ../gtk+-dev_2.24.10-1_win32.zip
+  - unzip ../glib-dev_2.28.8-1_win32.zip
+  - unzip ../atk-dev_1.32.0-2_win32.zip
+  - unzip ../pango-dev_1.29.4-1_win32.zip
+  - unzip ../gdk-pixbuf-dev_2.24.0-1_win32.zip
+  - unzip ../gdk-pixbuf_2.24.0-1_win32.zip
+  - unzip ../cairo-dev_1.10.2-2_win32.zip
+  - ls -lR
+  - cd ..
 script:
   - make android
   - make WINMINGW=i686-w64-mingw32 win


### PR DESCRIPTION
This pull requests adds the cross-compilation build for Windows to the Travis configuration. Additionally, the Linux and the Windows (by WINE) version of pktriggercord-cli are called with the version option as a very simple test of the build. 

I also reorganized the Windows part of the Makefile so the the command line tool can be compiled separately.

The purpose of these changes is the following suggestion to reorganize the Makefile. I think the object files and the final executables for the different operating systems should be build in separate directory. This would avoid the need to call make clean between the different builds. Also at the moment the directory structure is very flat with all source files/man page files etc. in on folder level. 

With Travis now executing all builds, such a reorganization should be possible more easily.