### PR TITLE
Smooth some things to be easier to integrate in libgphoto2

### DIFF
--- a/pslr.c
+++ b/pslr.c
@@ -92,10 +92,10 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...);
 #define ipslr_write_args(p,n,...) _ipslr_write_args(0,(p),(n),__VA_ARGS__)
 #define ipslr_write_args_special(p,n,...) _ipslr_write_args(4,(p),(n),__VA_ARGS__)
 
-static int command(int fd, int a, int b, int c);
-static int get_status(int fd);
-static int get_result(int fd);
-static int read_result(int fd, uint8_t *buf, uint32_t n);
+static int command(FDTYPE fd, int a, int b, int c);
+static int get_status(FDTYPE fd);
+static int get_result(FDTYPE fd);
+static int read_result(FDTYPE fd, uint8_t *buf, uint32_t n);
 
 void hexdump(uint8_t *buf, uint32_t bufLen);
 
@@ -349,7 +349,7 @@ pslr_gui_exposure_mode_t exposure_mode_conversion( pslr_exposure_mode_t exp ) {
 }
 
 pslr_handle_t pslr_init( char *model, char *device ) {
-    int fd;
+    FDTYPE fd;
     char vendorId[20];
     char productId[20];
     int driveNum;
@@ -396,7 +396,7 @@ pslr_handle_t pslr_init( char *model, char *device ) {
             } else {
                 DPRINT("\tCannot get drive info of Pentax camera. Please do not forget to install the program using 'make install'\n");
                 // found the camera but communication is not possible
-                close( fd );
+                close_drive( &fd );
                 continue;
             }
         } else {
@@ -1355,7 +1355,7 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
     va_list ap;
     uint8_t cmd[8] = {0xf0, 0x4f, cmd_2, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t buf[4 * n];
-    int fd = p->fd;
+    FDTYPE fd = p->fd;
     int res;
     int i;
     uint32_t data;
@@ -1416,7 +1416,7 @@ static int _ipslr_write_args(uint8_t cmd_2, ipslr_handle_t *p, int n, ...) {
 
 /* ----------------------------------------------------------------------- */
 
-static int command(int fd, int a, int b, int c) {
+static int command(FDTYPE fd, int a, int b, int c) {
     DPRINT("[C]\t\t\tcommand(fd=%x, %x, %x, %x)\n", fd, a, b, c);
     uint8_t cmd[8] = {0xf0, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
@@ -1428,7 +1428,7 @@ static int command(int fd, int a, int b, int c) {
     return PSLR_OK;
 }
 
-static int read_status(int fd, uint8_t *buf) {
+static int read_status(FDTYPE fd, uint8_t *buf) {
     uint8_t cmd[8] = {0xf0, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     int n;
 
@@ -1443,7 +1443,7 @@ static int read_status(int fd, uint8_t *buf) {
     return PSLR_OK;
 }
 
-static int get_status(int fd) {
+static int get_status(FDTYPE fd) {
     DPRINT("[C]\t\t\tget_status(0x%x)\n", fd);
 
     uint8_t statusbuf[8];
@@ -1465,7 +1465,7 @@ static int get_status(int fd) {
     return statusbuf[7];
 }
 
-static int get_result(int fd) {
+static int get_result(FDTYPE fd) {
     DPRINT("[C]\t\t\tget_result(0x%x)\n", fd);
     uint8_t statusbuf[8];
     while (1) {
@@ -1489,7 +1489,7 @@ static int get_result(int fd) {
     return statusbuf[0] | statusbuf[1] << 8 | statusbuf[2] << 16 | statusbuf[3] << 24;
 }
 
-static int read_result(int fd, uint8_t *buf, uint32_t n) {
+static int read_result(FDTYPE fd, uint8_t *buf, uint32_t n) {
     DPRINT("[C]\t\t\tread_result(0x%x, size=%d)\n", fd, n);
     uint8_t cmd[8] = {0xf0, 0x49, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     int r;

--- a/pslr_model.h
+++ b/pslr_model.h
@@ -136,7 +136,7 @@ typedef struct {
 } ipslr_segment_t;
 
 struct ipslr_handle {
-    int fd;
+    FDTYPE fd;
     pslr_status status;
     uint32_t id;
     ipslr_model_info_t *model;

--- a/pslr_scsi.h
+++ b/pslr_scsi.h
@@ -39,7 +39,12 @@ extern void write_debug( const char* message, ... );
 #include <android/log.h>
 #define DPRINT(...) __android_log_print(ANDROID_LOG_DEBUG, "PkTriggerCord", __VA_ARGS__)
 #else
+#ifdef LIBGPHOTO
+#include <gphoto2/gphoto2-log.h>
+#define DPRINT(x...) gp_log (GP_LOG_DEBUG, "pentax", x)
+#else
 #define DPRINT(x...) write_debug(x)
+#endif
 #endif
 
 typedef enum {
@@ -53,17 +58,26 @@ typedef enum {
     PSLR_ERROR_MAX
 } pslr_result;
 
-int scsi_read(int sg_fd, uint8_t *cmd, uint32_t cmdLen,
+/* This also could be used to specify FDTYPE HANDLE for Win32, but this seems tricky with includes */
+#ifdef LIBGPHOTO2
+typedef struct _GPPort GPPort;
+#define FDTYPE GPPort*
+#else
+/* classic UNIX style handle */
+#define FDTYPE int
+#endif
+
+int scsi_read(FDTYPE sg_fd, uint8_t *cmd, uint32_t cmdLen,
               uint8_t *buf, uint32_t bufLen);
 
-int scsi_write(int sg_fd, uint8_t *cmd, uint32_t cmdLen,
+int scsi_write(FDTYPE sg_fd, uint8_t *cmd, uint32_t cmdLen,
                uint8_t *buf, uint32_t bufLen);
 
 char **get_drives(int *driveNum);
 
-pslr_result get_drive_info(char* driveName, int* hDevice,
+pslr_result get_drive_info(char* driveName, FDTYPE* hDevice,
                            char* vendorId, int vendorIdSizeMax,
                            char* productId, int productIdSizeMax);
 
-void close_drive(int *hDevice);
+void close_drive(FDTYPE *hDevice);
 #endif


### PR DESCRIPTION
Use a "FDTYPE" define for the SCSI filedescriptor handle.
This will be "int" when a scsi generic device is used, HANDLE in Win32 and
GPPort* in libgphoto2.

Redefine DPRINT to use libgphoto2 logging.

https://github.com/asalamon74/pktriggercord/issues/21