### PR TITLE
Group plugdev doesn't necessarily exist

### DIFF
--- a/pentax.rules
+++ b/pentax.rules
@@ -6,9 +6,9 @@ SUBSYSTEM!="scsi_generic", GOTO="pentax_rules_end"
 
 LABEL="pentax_rules_start"
 # WAIT_FOR_SYSFS="device/vendor"
-ATTRS{vendor}=="PENTAX", ATTRS{model}=="DIGITAL_CAMERA", MODE="0666", GROUP="plugdev"
-ATTRS{vendor}=="PENTAX", ATTRS{model}=="DSC*", MODE="0666", GROUP="plugdev"
-ATTRS{vendor}=="RICOHIMG", ATTRS{model}=="DSC*", MODE="0666", GROUP="plugdev"
-ATTRS{vendor}=="PENTAX", ATTRS{model}=="K*", MODE="0666", GROUP="plugdev"
+ATTRS{vendor}=="PENTAX", ATTRS{model}=="DIGITAL_CAMERA", MODE="0666", GROUP="users"
+ATTRS{vendor}=="PENTAX", ATTRS{model}=="DSC*", MODE="0666", GROUP="users"
+ATTRS{vendor}=="RICOHIMG", ATTRS{model}=="DSC*", MODE="0666", GROUP="users"
+ATTRS{vendor}=="PENTAX", ATTRS{model}=="K*", MODE="0666", GROUP="users"
 
 LABEL="pentax_rules_end"

--- a/samsung.rules
+++ b/samsung.rules
@@ -6,8 +6,8 @@ SUBSYSTEM!="scsi_generic", GOTO="samsung_rules_end"
 
 LABEL="samsung_rules_start"
 # WAIT_FOR_SYSFS="device/vendor"
-ATTRS{vendor}=="SAMSUNG", ATTRS{model}=="DIGITAL_CAMERA", MODE="0666", GROUP="plugdev"
-ATTRS{vendor}=="SAMSUNG", ATTRS{model}=="DSC*", MODE="0666", GROUP="plugdev"
-ATTRS{vendor}=="SAMSUNG", ATTRS{model}=="K*", MODE="0666", GROUP="plugdev"
+ATTRS{vendor}=="SAMSUNG", ATTRS{model}=="DIGITAL_CAMERA", MODE="0666", GROUP="users"
+ATTRS{vendor}=="SAMSUNG", ATTRS{model}=="DSC*", MODE="0666", GROUP="users"
+ATTRS{vendor}=="SAMSUNG", ATTRS{model}=="K*", MODE="0666", GROUP="users"
 
 LABEL="samsung_rules_end"


### PR DESCRIPTION
Some distributions do not provide a group `plugdev` by default, e. g. Arch Linux. This will lead to boot messages like

```
 systemd-udevd[405]: Specified group 'plugdev' unknown
```

To see the logs: `journalctl -b -u systemd-udevd`.

Looking at other rules in `/etc/udev` I'd recommend replacing the group `plugdev` with `users`.

Thanks