### PR TITLE
K5II settings definitions

### DIFF
--- a/pentax_settings.json
+++ b/pentax_settings.json
@@ -14,7 +14,8 @@
 
     "0x12dfe": {
         "fields": [
-	        { "name" : "bulb_mode_press_press", "type": "boolean", "value": "false" },
+			{ "name" : "bulb_mode_press_press", "type": "boolean", "value": "false" },
+			{ "name" : "remote_bulb_mode_press_press", "type": "boolean!", "address": "0x132" },
 	        { "name" : "one_push_bracketing", "type": "boolean", "value": "false"},
 	        { "name" : "bulb_timer", "type": "boolean", "value": "false"},
 	        { "name" : "bulb_timer_sec", "type": "uint16", "value": 0 },
@@ -28,7 +29,8 @@
 
     "0x12f70": {
         "fields": [
-            { "name" : "bulb_mode_press_press", "type": "boolean!", "address": "0x0db" },
+			{ "name" : "bulb_mode_press_press", "type": "boolean", "value": "false" },
+			{ "name" : "remote_bulb_mode_press_press", "type": "boolean!", "address": "0x0db" },
             { "name" : "one_push_bracketing", "type": "boolean", "address": "0x0d1" },
             { "name" : "bulb_timer", "type": "boolean", "value": "false"},
             { "name" : "bulb_timer_sec", "type": "uint16", "value": 0 },

--- a/pentax_settings.json
+++ b/pentax_settings.json
@@ -26,6 +26,20 @@
 	    ]
     },
 
+    "0x12f70": {
+        "fields": [
+            { "name" : "bulb_mode_press_press", "type": "boolean!", "address": "0x0db" },
+            { "name" : "one_push_bracketing", "type": "boolean", "address": "0x0d1" },
+            { "name" : "bulb_timer", "type": "boolean", "value": "false"},
+            { "name" : "bulb_timer_sec", "type": "uint16", "value": 0 },
+            { "name" : "using_aperture_ring", "type": "boolean", "address": "0x0e3"},
+            { "name" : "shake_reduction", "type": "boolean!", "address": "0x092"},
+            { "name" : "astrotracer", "type": "boolean", "address": "0x0be"},
+            { "name" : "astrotracer_timer_sec", "type": "uint16", "address": "0x0bf"},
+            { "name" : "horizon_correction", "type": "boolean!", "address": "0x091"}
+	    ]
+    },
+
     "0x12fb6": {
         "fields": [
 	        { "name" : "bulb_mode_press_press", "type": "boolean", "address": "0x0f2" }

--- a/pslr.c
+++ b/pslr.c
@@ -614,6 +614,7 @@ char *collect_settings_info( pslr_handle_t h, pslr_settings settings ) {
     char *bulb_timer_sec = malloc(32);
     sprintf(bulb_timer_sec, "%d s", settings.bulb_timer_sec.value);
     sprintf(strbuffer+strlen(strbuffer),"%-32s: %-8s%s\n", "bulb timer sec", get_special_setting_info(settings.bulb_timer_sec.pslr_setting_status) ?: bulb_timer_sec, get_hardwired_setting_uint16_info(settings.bulb_timer_sec));
+    sprintf(strbuffer+strlen(strbuffer),"%-32s: %-8s%s\n", "remote bulb mode", get_special_setting_info(settings.remote_bulb_mode_press_press.pslr_setting_status) ?: settings.remote_bulb_mode_press_press.value ? "press-press" : "press-hold", get_hardwired_setting_bool_info(settings.remote_bulb_mode_press_press));
     sprintf(strbuffer+strlen(strbuffer),"%-32s: %-8s%s\n", "using aperture ring", get_special_setting_info(settings.using_aperture_ring.pslr_setting_status) ?: settings.using_aperture_ring.value ? "on" : "off", get_hardwired_setting_bool_info(settings.using_aperture_ring));
     sprintf(strbuffer+strlen(strbuffer),"%-32s: %-8s%s\n", "shake reduction", get_special_setting_info(settings.shake_reduction.pslr_setting_status) ?: settings.shake_reduction.value ? "on" : "off", get_hardwired_setting_bool_info(settings.shake_reduction));
     sprintf(strbuffer+strlen(strbuffer),"%-32s: %-8s%s\n", "astrotracer", get_special_setting_info(settings.astrotracer.pslr_setting_status) ?: settings.astrotracer.value ? "on" : "off", get_hardwired_setting_bool_info(settings.astrotracer));

--- a/pslr_model.c
+++ b/pslr_model.c
@@ -922,6 +922,8 @@ void ipslr_settings_parser_json(const char *cameraid, ipslr_handle_t *p, pslr_se
         }
         if (strcmp(def.name, "bulb_mode_press_press") == 0) {
             settings->bulb_mode_press_press = bool_setting;
+        } else if (strcmp(def.name, "remote_bulb_mode_press_press") == 0) {
+            settings->remote_bulb_mode_press_press = bool_setting;
         } else if (strcmp(def.name, "one_push_bracketing") == 0) {
             settings->one_push_bracketing = bool_setting;
         } else if (strcmp(def.name, "bulb_timer") == 0) {

--- a/pslr_model.h
+++ b/pslr_model.h
@@ -134,6 +134,7 @@ typedef struct {
     pslr_bool_setting astrotracer;
     pslr_uint16_setting astrotracer_timer_sec;
     pslr_bool_setting horizon_correction;
+    pslr_bool_setting remote_bulb_mode_press_press;
 } pslr_settings;
 
 typedef struct {


### PR DESCRIPTION
This PR adds settings definitions for the K5II. 

I've used `pktriggercord-cli.exe --settings_hex` to save and compare hex values between each change. I just have one doubt. Does `bulb_mode_press_press` actually refers to `Remote control in Bulb` in the third setting configuration page on the camera ? I mean, there is no notion of the "remote" in the pktriggercord setting name.

With a bit of luck, these settings might also work for the K5IIs (maybe even the K5) as they are virtually identical.

I also have the hex files at hand if you ever need them to cross check my findings 😄 