### PR TITLE
Ignore "loop" devices in get_drives.

### DIFF
--- a/pslr_scsi_linux.c
+++ b/pslr_scsi_linux.c
@@ -81,7 +81,7 @@ char **get_drives(int *drive_num) {
         d = opendir(device_dirs[di]);
         if (d) {
             while ( (ent = readdir(d)) ) {
-                if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0) {
+                if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0 && strncmp(ent->d_name, "loop",4) != 0) {
                     tmp[j] = malloc( strlen(ent->d_name)+1 );
                     strncpy(tmp[j], ent->d_name, strlen(ent->d_name)+1);
                     ++j;


### PR DESCRIPTION
This avoids a problem I was having on UbuntuMate 18.0.4 (installed on a Pi3) where a "loop" device existed for each snap package (e.g. loop0, loop1, etc.).  There were 2500+ "loop" devices, which filled up the tmp array in get_drives way beyond MAX_DEVICE_NUM, and caused a "stack smashing" error.

I could be wrong, but I don't think the cameras would ever have a name that starts with "loop", so I think this should be a valid solution.  

Another option might be to raise MAX_DEVICE_NUM to 10000+, which is probably pretty safe (this was a fresh install of UbuntuMate, so I don't know how many snap packages would be installed in the long run).