### PR TITLE
Fixed set_exposure_mode

### DIFF
--- a/pslr.c
+++ b/pslr.c
@@ -981,6 +981,11 @@ int pslr_set_exposure_mode(pslr_handle_t h, pslr_exposure_mode_t mode) {
     if (mode >= PSLR_EXPOSURE_MODE_MAX) {
         return PSLR_PARAM;
     }
+
+    if ( p->model->need_exposure_mode_conversion ) {
+        mode = exposure_mode_conversion( mode );
+    }
+    
     return ipslr_handle_command_x18( p, true, X18_EXPOSURE_MODE, 2, 1, mode, 0);
 }
 


### PR DESCRIPTION
This PR fixes  the ability to set the exposure mode for cameras that need a conversion step.

As per the code
> // most of the cameras require this exposure mode conversion step
> pslr_gui_exposure_mode_t exposure_mode_conversion( pslr_exposure_mode_t exp ) {

But `set_exposure_mode` didn't call that conversion step! As a result, setting the `exposure_mode` from the command line does not work correctly. For instance, `--exposure_mode=M` actually set the exposure mode to `X` (because `PSLR_EXPOSURE_MODE_M == PSLR_GUI_EXPOSURE_MODE_X== 8`).

`pktriggercord-cli.exe --drive_mode=Single --exposure_mode=M --iso=800 --shutter_speed="1/100" --output_file="test.dng"`

```
exiftool.exe test-0000.dng -ExposureMode -PictureMode
Exposure Mode                   : Manual
Picture Mode                    : Flash X-Sync Speed AE; 1/3 EV steps
Exposure Time                   : 1/180
```

After the fix
```
exiftool.exe test-0000.dng -ExposureMode -PictureMode -ExposureTime
Exposure Mode                   : Manual
Picture Mode                    : Manual, Off-Auto-Aperture; 1/3 EV steps
Exposure Time                   : 1/100
```

I can finally use both my K-5 and K-5 II in bulb or manual mode directly from the command line! 😄 