### PR TITLE
Libpktriggercord

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ MAN1DIR = $(MANDIR)/man1
 LIN_CFLAGS = $(CFLAGS)
 LIN_LDFLAGS = $(LDFLAGS)
 
+MAJORVERSION=0
 VERSION=0.85.01
 VERSIONCODE=$(shell echo $(VERSION) | sed s/\\.//g | sed s/^0// )
 # variables for RPM creation
@@ -40,12 +41,13 @@ LIN_GUI_CFLAGS=$(CFLAGS) $(shell pkg-config --cflags gtk+-2.0 gmodule-2.0) -DGTK
 default: cli pktriggercord
 all: srczip rpm win pktriggercord_commandline.html
 cli: pktriggercord-cli
+lib: libpktriggercord.so.$(VERSION)
 
 MANS = pktriggercord-cli.1 pktriggercord.1
 SRCOBJNAMES = pslr pslr_enum pslr_scsi pslr_lens pslr_model pktriggercord-servermode
 OBJS = $(SRCOBJNAMES:=.o) $(JSONDIR)/js0n.o
 WIN_DLLS_DIR=win_dlls
-SOURCE_PACKAGE_FILES = Makefile Changelog COPYING INSTALL BUGS $(MANS) pentax_scsi_protocol.md pentax.rules samsung.rules $(SRCOBJNAMES:=.h) $(SRCOBJNAMES:=.c) pslr_scsi_linux.c pslr_scsi_win.c pslr_scsi_openbsd.c exiftool_pentax_lens.txt pktriggercord.c pktriggercord-cli.c pktriggercord.ui pentax_settings.json $(SPECFILE) android_scsi_sg.h src/
+SOURCE_PACKAGE_FILES = Makefile Changelog COPYING INSTALL BUGS $(MANS) pentax_scsi_protocol.md pentax.rules samsung.rules $(SRCOBJNAMES:=.h) $(SRCOBJNAMES:=.c) pslr_scsi_linux.c pslr_scsi_win.c pslr_scsi_openbsd.c exiftool_pentax_lens.txt pktriggercord.c libpktriggercord.h libpktriggercord.c pktriggercord-cli.c pktriggercord.ui pentax_settings.json $(SPECFILE) android_scsi_sg.h src/
 TARDIR = pktriggercord-$(VERSION)
 SRCZIP = pkTriggerCord-$(VERSION).src.tar.gz
 
@@ -56,8 +58,15 @@ WINDIR=$(TARDIR)-win
 
 pslr.o: pslr_enum.o pslr_scsi.o pslr.c pslr.h
 
-pktriggercord-cli: pktriggercord-cli.c $(OBJS)
+pktriggercord-cli: pktriggercord-cli.c $(OBJS) libpktriggercord.o
 	$(CC) $(LIN_CFLAGS) $^ -DVERSION='"$(VERSION)"' -o $@ $(LIN_LDFLAGS) -L.
+
+libpktriggercord.so: libpktriggercord.so.$(VERSION)
+	ldconfig -v -n .
+	ln -s libpktriggercord.so.$(MAJORVERSION) libpktriggercord.so
+
+libpktriggercord.so.$(VERSION): $(OBJS) libpktriggercord.o
+	$(CC) $(LIN_CFLAGS) -shared -Wl,-soname,lib$(NAME).so.$(MAJORVERSION) $^ -o $@ $(LIN_LDFLAGS) -L.
 
 pslr_scsi.o: pslr_scsi_win.c pslr_scsi_linux.c pslr_scsi_openbsd.c
 
@@ -93,7 +102,7 @@ install: pktriggercord-cli pktriggercord
 	fi
 
 clean:
-	rm -f pktriggercord pktriggercord-cli *.o $(JSONDIR)/*.o
+	rm -f pktriggercord pktriggercord-cli *.o $(JSONDIR)/*.o *.so*
 	rm -f pktriggercord.exe pktriggercord-cli.exe
 	rm -f *.orig
 

--- a/libpktriggercord.c
+++ b/libpktriggercord.c
@@ -1,0 +1,201 @@
+/*
+    pkTriggerCord
+    Remote control of Pentax DSLR cameras.
+    Copyright (C) 2011-2019 Andras Salamon <andras.salamon@melda.info>
+
+    based on:
+
+    pslr-shoot
+
+    Command line remote control of Pentax DSLR cameras.
+    Copyright (C) 2009 Ramiro Barreiro <ramiro_barreiro69@yahoo.es>
+    With fragments of code from PK-Remote by Pontus Lidman.
+    <https://sourceforge.net/projects/pkremote>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    and GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libpktriggercord.h"
+
+bool debug = false;
+bool warnings = false;
+
+bool bulb_timer_before=false;
+bool astrotracer_before=false;
+
+int save_buffer(pslr_handle_t camhandle, int bufno, int fd, pslr_status *status, user_file_format filefmt, int jpeg_stars) {
+    pslr_buffer_type imagetype;
+    uint8_t buf[65536];
+    uint32_t length;
+    uint32_t current;
+
+    if (filefmt == USER_FILE_FORMAT_PEF) {
+        imagetype = PSLR_BUF_PEF;
+    } else if (filefmt == USER_FILE_FORMAT_DNG) {
+        imagetype = PSLR_BUF_DNG;
+    } else {
+        imagetype = pslr_get_jpeg_buffer_type( camhandle, jpeg_stars );
+    }
+
+    DPRINT("get buffer %d type %d res %d\n", bufno, imagetype, status->jpeg_resolution);
+
+    if (pslr_buffer_open(camhandle, bufno, imagetype, status->jpeg_resolution) != PSLR_OK) {
+        return 1;
+    }
+
+    length = pslr_buffer_get_size(camhandle);
+    DPRINT("Buffer length: %d\n", length);
+    current = 0;
+
+    while (true) {
+        uint32_t bytes;
+        bytes = pslr_buffer_read(camhandle, buf, sizeof (buf));
+        if (bytes == 0) {
+            break;
+        }
+        ssize_t r = write(fd, buf, bytes);
+        if (r == 0) {
+            DPRINT("write(buf): Nothing has been written to buf.\n");
+        } else if (r == -1) {
+            perror("write(buf)");
+        } else if (r < bytes) {
+            DPRINT("write(buf): only write %zu bytes, should be %d bytes.\n", r, bytes);
+        }
+        current += bytes;
+    }
+    pslr_buffer_close(camhandle);
+    return 0;
+}
+
+void save_memory(pslr_handle_t camhandle, int fd, uint32_t length) {
+    uint8_t buf[65536];
+    uint32_t current;
+
+    DPRINT("save memory %d\n", length);
+
+    current = 0;
+
+    while (current<length) {
+        uint32_t bytes;
+        int readsize=length-current>65536 ? 65536 : length-current;
+        bytes = pslr_fullmemory_read(camhandle, buf, current, readsize);
+        if (bytes == 0) {
+            break;
+        }
+        ssize_t r = write(fd, buf, bytes);
+        if (r == 0) {
+            DPRINT("write(buf): Nothing has been written to buf.\n");
+        } else if (r == -1) {
+            perror("write(buf)");
+        } else if (r < bytes) {
+            DPRINT("write(buf): only write %zu bytes, should be %d bytes.\n", r, bytes);
+        }
+        current += bytes;
+    }
+}
+
+int open_file(char* output_file, int frameNo, user_file_format_t ufft) {
+    int ofd;
+    char fileName[256];
+
+    if (!output_file) {
+        ofd = 1;
+    } else {
+        char *dot = strrchr(output_file, '.');
+        int prefix_length;
+        if (dot && !strcmp(dot+1, ufft.extension)) {
+            prefix_length = dot - output_file;
+        } else {
+            prefix_length = strlen(output_file);
+        }
+        snprintf(fileName, 256, "%.*s-%04d.%s", prefix_length, output_file, frameNo, ufft.extension);
+        ofd = open(fileName, FILE_ACCESS, 0664);
+        if (ofd == -1) {
+            fprintf(stderr, "Could not open %s\n", output_file);
+            return -1;
+        }
+    }
+    return ofd;
+}
+
+void warning_message( const char* message, ... ) {
+    if ( warnings ) {
+        // Write to stderr
+        //
+        va_list argp;
+        va_start(argp, message);
+        vfprintf( stderr, message, argp );
+        va_end(argp);
+    }
+}
+
+void process_wbadj( const char* argv0, const char chr, uint32_t adj, uint32_t *wbadj_mg, uint32_t *wbadj_ba ) {
+    if ( chr == 'M' ) {
+        *wbadj_mg = 7 - adj;
+    } else if ( chr == 'G' )  {
+        *wbadj_mg = 7 + adj;
+    } else if ( chr == 'B' ) {
+        *wbadj_ba = 7 - adj;
+    } else if ( chr == 'A' ) {
+        *wbadj_ba = 7 + adj;
+    } else {
+        warning_message("%s: Invalid white_balance_adjustment\n", argv0);
+    }
+}
+
+void bulb_old(pslr_handle_t camhandle, pslr_rational_t shutter_speed, struct timeval prev_time) {
+    DPRINT("bulb oldstyle\n");
+    struct timeval current_time;
+    pslr_bulb( camhandle, true );
+    pslr_shutter(camhandle);
+    gettimeofday(&current_time, NULL);
+    double waitsec = 1.0 * shutter_speed.nom / shutter_speed.denom - timeval_diff_sec(&current_time, &prev_time);
+    if ( waitsec < 0 ) {
+        waitsec = 0;
+    }
+    sleep_sec( waitsec  );
+    pslr_bulb( camhandle, false );
+}
+
+void bulb_new(pslr_handle_t camhandle, pslr_rational_t shutter_speed) {
+    if (pslr_has_setting_by_name(camhandle, "bulb_timer")) {
+        pslr_write_setting_by_name(camhandle, "bulb_timer", 1);
+    } else if (pslr_has_setting_by_name(camhandle, "astrotracer")) {
+        pslr_write_setting_by_name(camhandle, "astrotracer", 1);
+    } else {
+        fprintf(stderr, "New bulb mode is not supported for this camera model\n");
+    }
+    int bulb_sec = (int)(shutter_speed.nom / shutter_speed.denom);
+    if (pslr_has_setting_by_name(camhandle, "bulb_timer_sec")) {
+        pslr_write_setting_by_name(camhandle, "bulb_timer_sec", bulb_sec);
+    } else if (pslr_has_setting_by_name(camhandle, "astrotracer_timer_sec")) {
+        pslr_write_setting_by_name(camhandle, "astrotracer_timer_sec", bulb_sec);
+    } else {
+        fprintf(stderr, "New bulb mode is not supported for this camera model\n");
+    }
+    pslr_shutter(camhandle);
+}
+
+void bulb_new_cleanup(pslr_handle_t camhandle) {
+    if (pslr_has_setting_by_name(camhandle, "bulb_timer")) {
+        if (!bulb_timer_before) {
+            pslr_write_setting_by_name(camhandle, "bulb_timer", bulb_timer_before);
+        }
+    } else if (pslr_has_setting_by_name(camhandle, "astrotracer")) {
+        if (!astrotracer_before) {
+            pslr_write_setting_by_name(camhandle, "astrotracer", astrotracer_before);
+        }
+    }
+}

--- a/libpktriggercord.h
+++ b/libpktriggercord.h
@@ -1,0 +1,84 @@
+/*
+    Header file for libpktriggercord
+    Shared library wrapper for pkTriggerCord
+    Copyright (c) 2020 Karl Rees
+
+    for:
+
+    pkTriggerCord
+    Remote control of Pentax DSLR cameras.
+    Copyright (C) 2011-2019 Andras Salamon <andras.salamon@melda.info>
+
+    which is based on:
+
+    pslr-shoot
+
+    Command line remote control of Pentax DSLR cameras.
+    Copyright (C) 2009 Ramiro Barreiro <ramiro_barreiro69@yahoo.es>
+    With fragments of code from PK-Remote by Pontus Lidman.
+    <https://sourceforge.net/projects/pkremote>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    and GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBPKTRIGGERCORD_H
+#define LIBPKTRIGGERCORD_H
+
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <fcntl.h>
+#include <ctype.h>
+#include <time.h>
+#include <stdarg.h>
+#include <math.h>
+#include <sys/time.h>
+
+#include "pslr.h"
+#include "pktriggercord-servermode.h"
+
+#ifdef WIN32
+#define FILE_ACCESS O_WRONLY | O_CREAT | O_TRUNC | O_BINARY
+#else
+#define FILE_ACCESS O_WRONLY | O_CREAT | O_TRUNC
+#endif
+
+extern bool debug;
+extern bool warnings;
+
+extern bool bulb_timer_before;
+extern bool astrotracer_before;
+
+
+int save_buffer(pslr_handle_t camhandle, int bufno, int fd, pslr_status *status, user_file_format filefmt, int jpeg_stars);
+void save_memory(pslr_handle_t camhandle, int fd, uint32_t length);
+
+void print_status_info( pslr_handle_t h, pslr_status status );
+void print_settings_info( pslr_handle_t h, pslr_settings settings );
+
+int open_file(char* output_file, int frameNo, user_file_format_t ufft);
+void warning_message( const char* message, ... );
+
+void process_wbadj( const char* argv0, const char chr, uint32_t adj, uint32_t *wbadj_mg, uint32_t *wbadj_ba );
+
+void bulb_old(pslr_handle_t camhandle, pslr_rational_t shutter_speed, struct timeval prev_time);
+void bulb_new(pslr_handle_t camhandle, pslr_rational_t shutter_speed);
+void bulb_new_cleanup(pslr_handle_t camhandle);
+
+#endif

--- a/pktriggercord-cli.c
+++ b/pktriggercord-cli.c
@@ -27,39 +27,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdbool.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <getopt.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <time.h>
-#include <stdarg.h>
-#include <math.h>
-#include <sys/time.h>
+#include "libpktriggercord.h"
 
-#include "pslr.h"
-#include "pktriggercord-servermode.h"
-
-#ifdef WIN32
-#define FILE_ACCESS O_WRONLY | O_CREAT | O_TRUNC | O_BINARY
-#else
-#define FILE_ACCESS O_WRONLY | O_CREAT | O_TRUNC
-#endif
-
-bool debug = false;
-bool warnings = false;
-
-const char *shortopts = "m:q:a:r:d:t:o:i:F:fghvsSw";
-
-pslr_settings settings;
-bool bulb_timer_before=false;
-bool astrotracer_before=false;
 bool need_bulb_new_cleanup=false;
 bool need_one_push_bracketing_cleanup=false;
+
+pslr_settings settings;
+
+
+const char *shortopts = "m:q:a:r:d:t:o:i:F:fghvsSw";
 
 static struct option const longopts[] = {
     {"exposure_mode", required_argument, NULL, 'm'},
@@ -109,78 +85,6 @@ static struct option const longopts[] = {
     {"settings", no_argument, NULL, 'S'},
     { NULL, 0, NULL, 0}
 };
-
-int save_buffer(pslr_handle_t camhandle, int bufno, int fd, pslr_status *status, user_file_format filefmt, int jpeg_stars) {
-    pslr_buffer_type imagetype;
-    uint8_t buf[65536];
-    uint32_t length;
-    uint32_t current;
-
-    if (filefmt == USER_FILE_FORMAT_PEF) {
-        imagetype = PSLR_BUF_PEF;
-    } else if (filefmt == USER_FILE_FORMAT_DNG) {
-        imagetype = PSLR_BUF_DNG;
-    } else {
-        imagetype = pslr_get_jpeg_buffer_type( camhandle, jpeg_stars );
-    }
-
-    DPRINT("get buffer %d type %d res %d\n", bufno, imagetype, status->jpeg_resolution);
-
-    if (pslr_buffer_open(camhandle, bufno, imagetype, status->jpeg_resolution) != PSLR_OK) {
-        return 1;
-    }
-
-    length = pslr_buffer_get_size(camhandle);
-    DPRINT("Buffer length: %d\n", length);
-    current = 0;
-
-    while (true) {
-        uint32_t bytes;
-        bytes = pslr_buffer_read(camhandle, buf, sizeof (buf));
-        if (bytes == 0) {
-            break;
-        }
-        ssize_t r = write(fd, buf, bytes);
-        if (r == 0) {
-            DPRINT("write(buf): Nothing has been written to buf.\n");
-        } else if (r == -1) {
-            perror("write(buf)");
-        } else if (r < bytes) {
-            DPRINT("write(buf): only write %zu bytes, should be %d bytes.\n", r, bytes);
-        }
-        current += bytes;
-    }
-    pslr_buffer_close(camhandle);
-    return 0;
-}
-
-void save_memory(pslr_handle_t camhandle, int fd, uint32_t length) {
-    uint8_t buf[65536];
-    uint32_t current;
-
-    DPRINT("save memory %d\n", length);
-
-    current = 0;
-
-    while (current<length) {
-        uint32_t bytes;
-        int readsize=length-current>65536 ? 65536 : length-current;
-        bytes = pslr_fullmemory_read(camhandle, buf, current, readsize);
-        if (bytes == 0) {
-            break;
-        }
-        ssize_t r = write(fd, buf, bytes);
-        if (r == 0) {
-            DPRINT("write(buf): Nothing has been written to buf.\n");
-        } else if (r == -1) {
-            perror("write(buf)");
-        } else if (r < bytes) {
-            DPRINT("write(buf): only write %zu bytes, should be %d bytes.\n", r, bytes);
-        }
-        current += bytes;
-    }
-}
-
 
 void print_status_info( pslr_handle_t h, pslr_status status ) {
     printf("\n");
@@ -242,55 +146,6 @@ void usage(char *name) {
 \n", name);
 }
 
-int open_file(char* output_file, int frameNo, user_file_format_t ufft) {
-    int ofd;
-    char fileName[256];
-
-    if (!output_file) {
-        ofd = 1;
-    } else {
-        char *dot = strrchr(output_file, '.');
-        int prefix_length;
-        if (dot && !strcmp(dot+1, ufft.extension)) {
-            prefix_length = dot - output_file;
-        } else {
-            prefix_length = strlen(output_file);
-        }
-        snprintf(fileName, 256, "%.*s-%04d.%s", prefix_length, output_file, frameNo, ufft.extension);
-        ofd = open(fileName, FILE_ACCESS, 0664);
-        if (ofd == -1) {
-            fprintf(stderr, "Could not open %s\n", output_file);
-            return -1;
-        }
-    }
-    return ofd;
-}
-
-void warning_message( const char* message, ... ) {
-    if ( warnings ) {
-        // Write to stderr
-        //
-        va_list argp;
-        va_start(argp, message);
-        vfprintf( stderr, message, argp );
-        va_end(argp);
-    }
-}
-
-void process_wbadj( const char* argv0, const char chr, uint32_t adj, uint32_t *wbadj_mg, uint32_t *wbadj_ba ) {
-    if ( chr == 'M' ) {
-        *wbadj_mg = 7 - adj;
-    } else if ( chr == 'G' )  {
-        *wbadj_mg = 7 + adj;
-    } else if ( chr == 'B' ) {
-        *wbadj_ba = 7 - adj;
-    } else if ( chr == 'A' ) {
-        *wbadj_ba = 7 + adj;
-    } else {
-        warning_message("%s: Invalid white_balance_adjustment\n", argv0);
-    }
-}
-
 char *copyright_version(char *name, char *version) {
     char *ret = malloc(sizeof(char)*1024);
     sprintf(ret, "%s %s\n\n\%s\
@@ -313,51 +168,6 @@ char *command_line(int argc, char **argv) {
         strcat(ret, " ");
     }
     return ret;
-}
-
-void bulb_old(pslr_handle_t camhandle, pslr_rational_t shutter_speed, struct timeval prev_time) {
-    DPRINT("bulb oldstyle\n");
-    struct timeval current_time;
-    pslr_bulb( camhandle, true );
-    pslr_shutter(camhandle);
-    gettimeofday(&current_time, NULL);
-    double waitsec = 1.0 * shutter_speed.nom / shutter_speed.denom - timeval_diff_sec(&current_time, &prev_time);
-    if ( waitsec < 0 ) {
-        waitsec = 0;
-    }
-    sleep_sec( waitsec  );
-    pslr_bulb( camhandle, false );
-}
-
-void bulb_new(pslr_handle_t camhandle, pslr_rational_t shutter_speed) {
-    if (pslr_has_setting_by_name(camhandle, "bulb_timer")) {
-        pslr_write_setting_by_name(camhandle, "bulb_timer", 1);
-    } else if (pslr_has_setting_by_name(camhandle, "astrotracer")) {
-        pslr_write_setting_by_name(camhandle, "astrotracer", 1);
-    } else {
-        fprintf(stderr, "New bulb mode is not supported for this camera model\n");
-    }
-    int bulb_sec = (int)(shutter_speed.nom / shutter_speed.denom);
-    if (pslr_has_setting_by_name(camhandle, "bulb_timer_sec")) {
-        pslr_write_setting_by_name(camhandle, "bulb_timer_sec", bulb_sec);
-    } else if (pslr_has_setting_by_name(camhandle, "astrotracer_timer_sec")) {
-        pslr_write_setting_by_name(camhandle, "astrotracer_timer_sec", bulb_sec);
-    } else {
-        fprintf(stderr, "New bulb mode is not supported for this camera model\n");
-    }
-    pslr_shutter(camhandle);
-}
-
-void bulb_new_cleanup(pslr_handle_t camhandle) {
-    if (pslr_has_setting_by_name(camhandle, "bulb_timer")) {
-        if (!bulb_timer_before) {
-            pslr_write_setting_by_name(camhandle, "bulb_timer", bulb_timer_before);
-        }
-    } else if (pslr_has_setting_by_name(camhandle, "astrotracer")) {
-        if (!astrotracer_before) {
-            pslr_write_setting_by_name(camhandle, "astrotracer", astrotracer_before);
-        }
-    }
 }
 
 int main(int argc, char **argv) {

--- a/pslr_scsi_linux.c
+++ b/pslr_scsi_linux.c
@@ -81,7 +81,7 @@ char **get_drives(int *drive_num) {
         d = opendir(device_dirs[di]);
         if (d) {
             while ( (ent = readdir(d)) ) {
-                if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0) {
+                if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0 && strncmp(ent->d_name, "loop",4) != 0) {
                     tmp[j] = malloc( strlen(ent->d_name)+1 );
                     strncpy(tmp[j], ent->d_name, strlen(ent->d_name)+1);
                     ++j;


### PR DESCRIPTION
Initial support for library version.

These are the changes I made when I first tried to get the pktriggercord make file to compile a library version.  I didn't get around to having it install the library or deal with packaging.  I think part of the reason I eventually gave up was I wasn't quite sure what the preferred install/packaging behavior should be.  That, and I didn't think the library would be very user-friendly without moving all of the code into a unique namespace, which I didn't feel up to doing at the time.

(The libpktriggercord package I eventually produced for INDI used a stripped down version of the source code and cmake to build/install.  So that obviously wouldn't integrate well back into the original code base at the moment).