### PR TITLE
Fix C99 compatibility issue with sprintf() in pslr_enum.c.

### DIFF
--- a/pslr_enum.c
+++ b/pslr_enum.c
@@ -296,10 +296,14 @@ char *get_pslr_af11_point_str( uint32_t value ) {
     }
     int bitidx=0;
     char *ret = malloc(1024);
-    sprintf(ret, "%s", "");
+    int pos = sprintf(ret, "%s", "");
     while (value>0 && bitidx<11) {
         if ((value & 0x01) == 1) {
-            sprintf(ret, "%s%s%s", ret, strlen(ret) == 0 ? "" : ",", pslr_af11_point_str[bitidx]);
+            int written = sprintf(ret + pos, "%s%s", pos == 0 ? "" : ",", pslr_af11_point_str[bitidx]);
+            if (written < 0) {
+                return ret;
+            }
+            pos += written;
         }
         value >>= 1;
         ++bitidx;


### PR DESCRIPTION
Since C99 standard, sprintf(...) has 'restrict' buffer qualifier and cannot accept same buffer as both source and destination. The string appending method has now been changed to be compliant to this requirement.

I do not have a Pentax camera so it would be nice if someone did testing. Generally I'm pretty confident that this change will not cause issues.