### PR TITLE
Replace strncpy() with memcpy() in pslr_scsi_linux.c.

### DIFF
--- a/pslr_scsi_linux.c
+++ b/pslr_scsi_linux.c
@@ -83,7 +83,7 @@ char **get_drives(int *drive_num) {
             while ( (ent = readdir(d)) ) {
                 if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0 && strncmp(ent->d_name, "loop",4) != 0) {
                     tmp[j] = malloc( strlen(ent->d_name)+1 );
-                    strncpy(tmp[j], ent->d_name, strlen(ent->d_name)+1);
+                    memcpy(tmp[j], ent->d_name, strlen(ent->d_name)+1);
                     ++j;
                 }
             }
@@ -97,7 +97,7 @@ char **get_drives(int *drive_num) {
         ret = malloc( j * sizeof(char*) );
         for ( jj=0; jj<j; ++jj ) {
             ret[jj] = malloc( strlen(tmp[jj])+1 );
-            strncpy( ret[jj], tmp[jj], strlen(tmp[jj]) );
+            memcpy( ret[jj], tmp[jj], strlen(tmp[jj]) );
             ret[jj][strlen(tmp[jj])]='\0';
         }
     }


### PR DESCRIPTION
Compilers like recent GCC versions will complain about using strncpy() in pslr_scsi_linux.c. This is because strncpy() is traditionally used with length argument dependent on destination string length. In this code, however, the length is dependent on source string size. It is therefore recommended to use memcpy() instead.

I have no way of testing this change, but it is very straightforward so I'm confident that it will not cause issues.