### PR TITLE
Fixes compiler warnings in pslr_model.c.

### DIFF
--- a/pslr_model.c
+++ b/pslr_model.c
@@ -807,7 +807,11 @@ char *read_json_file(int *jsonsize) {
     *jsonsize = lseek(jsonfd, 0, SEEK_END);
     lseek(jsonfd, 0, SEEK_SET);
     char *jsontext=malloc(*jsonsize);
-    read(jsonfd, jsontext, *jsonsize);
+    ssize_t ret = read(jsonfd, jsontext, *jsonsize);
+    if (ret < *jsonsize) {
+        fprintf(stderr, "Could not read pentax_settings.json file\n");
+        return NULL;
+    }
     DPRINT("json text:\n%.*s\n", *jsonsize, jsontext);
     return jsontext;
 }

--- a/pslr_model.c
+++ b/pslr_model.c
@@ -1007,7 +1007,7 @@ ipslr_model_info_t camera_models[] = {
 };
 
 ipslr_model_info_t *find_model_by_id( uint32_t id ) {
-    int i;
+    unsigned int i;
     for ( i = 0; i<sizeof (camera_models) / sizeof (camera_models[0]); i++) {
         if ( camera_models[i].id == id ) {
             //    DPRINT("found %d\n",i);


### PR DESCRIPTION
This PR consists of two commits fixing two different issues.

Commits:
* Adds a check to see if read() succeeded or not. This also quiets compiler warning about read() return value not being checked.
* This fix quiets compiler warning about signed-unsigned comparison in 'for' loop. The 'for' loop is trivial and variable 'i' is already implicitly used as unsigned value in the loop comparison.

Again, I have no way of testing the changes, but they are fairly straightforward.