### PR TITLE
Fixes compiler warnings in pslr.c.

### DIFF
--- a/pslr.c
+++ b/pslr.c
@@ -1070,7 +1070,7 @@ int pslr_buffer_open(pslr_handle_t h, int bufno, pslr_buffer_type buftype, int b
 
 uint32_t pslr_buffer_read(pslr_handle_t h, uint8_t *buf, uint32_t size) {
     ipslr_handle_t *p = (ipslr_handle_t *) h;
-    int i;
+    uint32_t i;
     uint32_t pos = 0;
     uint32_t seg_offs;
     uint32_t addr;
@@ -1125,7 +1125,7 @@ uint32_t pslr_fullmemory_read(pslr_handle_t h, uint8_t *buf, uint32_t offset, ui
 
 uint32_t pslr_buffer_get_size(pslr_handle_t h) {
     ipslr_handle_t *p = (ipslr_handle_t *) h;
-    int i;
+    uint32_t i;
     uint32_t len = 0;
     for (i = 0; i < p->segment_count; i++) {
         len += p->segments[i].length;
@@ -1778,10 +1778,10 @@ static int read_result(FDTYPE fd, uint8_t *buf, uint32_t n) {
     DPRINT("[C]\t\t\tread_result(0x%x, size=%d)\n", fd, n);
     uint8_t cmd[8] = {0xf0, 0x49, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     int r;
-    int i;
+    uint32_t i;
     set_uint32_le(n, &cmd[4]);
     r = scsi_read(fd, cmd, sizeof (cmd), buf, n);
-    if (r != n) {
+    if ((uint32_t)r != n) {
         return PSLR_READ_ERROR;
     }  else {
         //  Print first 32 bytes of the result.

--- a/pslr.c
+++ b/pslr.c
@@ -376,7 +376,7 @@ pslr_handle_t pslr_init( char *model, char *device ) {
         driveNum = 1;
         drives = malloc( driveNum * sizeof(char*) );
         drives[0] = malloc( strlen( device )+1 );
-        strncpy( drives[0], device, strlen( device ) );
+        memcpy( drives[0], device, strlen( device ) );
         drives[0][strlen(device)]='\0';
     }
     DPRINT("driveNum:%d\n",driveNum);


### PR DESCRIPTION
This PR consists of two commits fixing two different issues.

Commits:
* Fixes compiler warning about using strncpy() with length argument derived from source string. This is the same change as in PR #56.
* Compilers complain about signed-unsigned comparisons in 'for' loops. Change variable 'i' type to 'uint32_t'. This will not change behavior of existing code as 'i' was already compared in unsigned mode. Also add cast to variable 'r' to quell compiler warning about signed-unsigned comparison.

Again, I have no way of testing the changes, but they are fairly straightforward.