### PR TITLE
Fix write() result checking in pktriggercord-servermode.c.

### DIFF
--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -95,14 +95,14 @@ int client_sock;
 
 void write_socket_answer( char *answer ) {
     ssize_t r = write(client_sock, answer, strlen(answer));
-    if (r != strlen(answer)) {
+    if (r < 0 || (size_t)r != strlen(answer)) {
         fprintf(stderr, "write(answer) failed");
     }
 }
 
 void write_socket_answer_bin( uint8_t *answer, uint32_t length ) {
     ssize_t r = write(client_sock, answer, length);
-    if (r != length) {
+    if (r < 0 || (size_t)r != length) {
         fprintf(stderr, "write(answer) failed");
     }
 


### PR DESCRIPTION
This fixes signed-unsigned compare issue in checking write() result. It will quiet compiler warnings, but has no real impact on code behavior.

Again, I have no way of testing the changes, but they are fairly straightforward.