### PR TITLE
replaced some weird string allocate + copy constructs by just doing strdup

### DIFF
--- a/pktriggercord.c
+++ b/pktriggercord.c
@@ -288,9 +288,7 @@ int common_init(void) {
     char **fileformatnames = malloc( numfileformats * sizeof(char*) );
     int i;
     for (i = 0; i<numfileformats; i++) {
-        fileformatnames[i] = malloc( strlen(file_formats[i].file_format_name)+1);
-        memset( fileformatnames[i], '\0', strlen(file_formats[i].file_format_name)+1);
-        strncpy( fileformatnames[i], file_formats[i].file_format_name, strlen( file_formats[i].file_format_name ));
+        fileformatnames[i] = strdup( file_formats[i].file_format_name );
     }
 
     combobox_append( pw, fileformatnames, numfileformats );

--- a/pslr.c
+++ b/pslr.c
@@ -375,9 +375,7 @@ pslr_handle_t pslr_init( char *model, char *device ) {
     } else {
         driveNum = 1;
         drives = malloc( driveNum * sizeof(char*) );
-        drives[0] = malloc( strlen( device )+1 );
-        memcpy( drives[0], device, strlen( device ) );
-        drives[0][strlen(device)]='\0';
+        drives[0] = strdup( device );
     }
     DPRINT("driveNum:%d\n",driveNum);
     int i;

--- a/pslr_scsi_linux.c
+++ b/pslr_scsi_linux.c
@@ -82,8 +82,7 @@ char **get_drives(int *drive_num) {
         if (d) {
             while ( (ent = readdir(d)) ) {
                 if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0 && strncmp(ent->d_name, "loop",4) != 0) {
-                    tmp[j] = malloc( strlen(ent->d_name)+1 );
-                    memcpy(tmp[j], ent->d_name, strlen(ent->d_name)+1);
+                    tmp[j] = strdup( ent->d_name );
                     ++j;
                 }
             }
@@ -96,9 +95,7 @@ char **get_drives(int *drive_num) {
     if (j>0) {
         ret = malloc( j * sizeof(char*) );
         for ( jj=0; jj<j; ++jj ) {
-            ret[jj] = malloc( strlen(tmp[jj])+1 );
-            memcpy( ret[jj], tmp[jj], strlen(tmp[jj]) );
-            ret[jj][strlen(tmp[jj])]='\0';
+            ret[jj] = tmp[jj];
         }
     }
     return ret;


### PR DESCRIPTION
replaced some weird string allocate + copy constructs by just doing strdup() which does the same thing

also remove one string memory duplication in get_drives, as we would leak memory.