### PR TITLE
Added set_aperture to servermode

### DIFF
--- a/pktriggercord-cli.1
+++ b/pktriggercord-cli.1
@@ -411,6 +411,11 @@ Get the image buffer\.
 Set shutter speed\.
 .RE
 .PP
+\fBset_aperture\fR \fIAPERTURE\fR
+.RS 4
+Set aperture\.
+.RE
+.PP
 \fBset_iso\fR \fIISO\fR
 .RS 4
 Set ISO\.

--- a/pktriggercord-cli.c
+++ b/pktriggercord-cli.c
@@ -634,21 +634,9 @@ int main(int argc, char **argv) {
                 break;
 
             case 'a':
-                if (sscanf(optarg, "%f%c", &F, &C) != 1) {
-                    F = 0;
-                }
-                /*It's unlikely that you want an f-number > 100, even for a pinhole.
-                 On the other hand, the fastest lens I know of is a f:0.8 Zeiss*/
-                if (F > 100 || F < 0.8) {
+                aperture = parse_aperture(optarg);
+                if (aperture.nom == 0) {
                     warning_message( "%s: Invalid aperture value.\n", argv[0]);
-                }
-                if (F >= 11) {
-                    aperture.nom = F;
-                    aperture.denom = 1;
-                } else {
-                    F = (F * 10.0);
-                    aperture.nom = F;
-                    aperture.denom = 10;
                 }
                 break;
 

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -171,7 +171,7 @@ int servermode_socket(int servermode_timeout) {
     char C;
     pslr_rational_t shutter_speed = {0, 0};
     pslr_rational_t aperture = {0, 0};
-	uint32_t iso = 0;
+    uint32_t iso = 0;
     uint32_t auto_iso_min = 0;
     uint32_t auto_iso_max = 0;
 
@@ -383,14 +383,14 @@ int servermode_socket(int servermode_timeout) {
                 }
             } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
                 if ( check_camera(camhandle) ) {
-					aperture.nom = atof(arg) * 10 ;
-					aperture.denom = 10 ;
+                    aperture.nom = atof(arg) * 10 ;
+                    aperture.denom = 10 ;
                     if (aperture.nom) {
                         pslr_set_aperture(camhandle, aperture);
-						sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
+                        sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
                     } else {
-                      	aperture.nom = 0;
-                      	sprintf(buf,"1 Invalid aperture value.\n");
+                        aperture.nom = 0;
+                        sprintf(buf,"1 Invalid aperture value.\n");
                     }
                     write_socket_answer(buf);
                 }

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -170,7 +170,8 @@ int servermode_socket(int servermode_timeout) {
     pslr_status status;
     char C;
     pslr_rational_t shutter_speed = {0, 0};
-    uint32_t iso = 0;
+    pslr_rational_t aperture = {0, 0};
+		uint32_t iso = 0;
     uint32_t auto_iso_min = 0;
     uint32_t auto_iso_max = 0;
 
@@ -377,6 +378,19 @@ int servermode_socket(int servermode_timeout) {
                     } else {
                         sprintf(buf, "%d %d %d\n", 0, shutter_speed.nom, shutter_speed.denom);
                         pslr_set_shutter(camhandle, shutter_speed);
+                    }
+                    write_socket_answer(buf);
+                }
+            } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
+                if ( check_camera(camhandle) ) {
+									  aperture.nom = atof(arg) * 10 ;
+										aperture.denom = 10 ;
+                    if (aperture.nom) {
+                        pslr_set_aperture(camhandle, aperture);
+												sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
+                    } else {
+                      	aperture.nom = 0;
+                      	sprintf(buf,"1 Invalid aperture value.\n");
                     }
                     write_socket_answer(buf);
                 }

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -171,7 +171,7 @@ int servermode_socket(int servermode_timeout) {
     char C;
     pslr_rational_t shutter_speed = {0, 0};
     pslr_rational_t aperture = {0, 0};
-		uint32_t iso = 0;
+	uint32_t iso = 0;
     uint32_t auto_iso_min = 0;
     uint32_t auto_iso_max = 0;
 
@@ -383,11 +383,11 @@ int servermode_socket(int servermode_timeout) {
                 }
             } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
                 if ( check_camera(camhandle) ) {
-									  aperture.nom = atof(arg) * 10 ;
-										aperture.denom = 10 ;
+					aperture.nom = atof(arg) * 10 ;
+					aperture.denom = 10 ;
                     if (aperture.nom) {
                         pslr_set_aperture(camhandle, aperture);
-												sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
+						sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
                     } else {
                       	aperture.nom = 0;
                       	sprintf(buf,"1 Invalid aperture value.\n");

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -383,8 +383,8 @@ int servermode_socket(int servermode_timeout) {
                 }
             } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
                 if ( check_camera(camhandle) ) {
-                    aperture.nom = atof(arg) * 10 ;
-                    aperture.denom = 10 ;
+                    aperture.nom = atof(arg) * 10;
+                    aperture.denom = 10;
                     if (aperture.nom) {
                         pslr_set_aperture(camhandle, aperture);
                         sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);

--- a/pktriggercord-servermode.h
+++ b/pktriggercord-servermode.h
@@ -37,5 +37,6 @@ void camera_close(pslr_handle_t camhandle);
 
 double timeval_diff_sec(struct timeval *t2, struct timeval *t1);
 pslr_rational_t parse_shutter_speed(char *shutter_speed_str);
+pslr_rational_t parse_aperture(char *aperture_str);
 
 #endif


### PR DESCRIPTION
Servermode didn't previously support setting the camera's aperture; this change adds the set_aperture command to allow the aperture to be adjusted.

Tested on a Pentax K10D (connected to a Raspberry Pi 4B) and it seems to work as expected.