### PR TITLE
Added set_buffer_type and get_buffer_type commands to servermode, to enable downloading images as PEF instead of DNG

### DIFF
--- a/pktriggercord-cli.1
+++ b/pktriggercord-cli.1
@@ -406,6 +406,16 @@ Get the preview buffer\.
 Get the image buffer\.
 .RE
 .PP
+\fBget_buffer_type\fR
+.RS 4
+Get the current buffer type for images downloaded from the camera (DNG or PEF)\.
+.RE
+.PP
+\fBset_buffer_type\fR \fIBUFFER_TYPE\fR
+.RS 4
+Set the buffer type for images downloaded from the camera (defaults to DNG, valid values are "DNG" or "PEF")\.
+.RE
+.PP
 \fBset_shutter_speed\fR \fISHUTTER_SPEED\fR
 .RS 4
 Set shutter speed\.

--- a/pktriggercord-cli.1
+++ b/pktriggercord-cli.1
@@ -421,11 +421,6 @@ Set the buffer type for images downloaded from the camera (defaults to DNG, vali
 Set shutter speed\.
 .RE
 .PP
-\fBset_aperture\fR \fIAPERTURE\fR
-.RS 4
-Set aperture\.
-.RE
-.PP
 \fBset_iso\fR \fIISO\fR
 .RS 4
 Set ISO\.

--- a/pktriggercord-cli.1
+++ b/pktriggercord-cli.1
@@ -411,6 +411,11 @@ Get the image buffer\.
 Set shutter speed\.
 .RE
 .PP
+\fBset_aperture\fR \fIAPERTURE\fR
+.RS 4
+Set aperture\.
+.RE
+.PP
 \fBset_iso\fR \fIISO\fR
 .RS 4
 Set ISO\.

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -171,7 +171,7 @@ int servermode_socket(int servermode_timeout) {
     char C;
     pslr_rational_t shutter_speed = {0, 0};
     pslr_rational_t aperture = {0, 0};
-	uint32_t iso = 0;
+    uint32_t iso = 0;
     uint32_t auto_iso_min = 0;
     uint32_t auto_iso_max = 0;
 
@@ -383,14 +383,14 @@ int servermode_socket(int servermode_timeout) {
                 }
             } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
                 if ( check_camera(camhandle) ) {
-					aperture.nom = atof(arg) * 10 ;
-					aperture.denom = 10 ;
+                    aperture.nom = atof(arg) * 10 ;
+                    aperture.denom = 10 ;
                     if (aperture.nom) {
                         pslr_set_aperture(camhandle, aperture);
-						sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
+                        sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
                     } else {
-                      	aperture.nom = 0;
-                      	sprintf(buf,"1 Invalid aperture value.\n");
+                        aperture.nom = 0;
+                        sprintf(buf,"1 Invalid aperture value.\n");
                     }
                     write_socket_answer(buf);
                 }

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -170,7 +170,8 @@ int servermode_socket(int servermode_timeout) {
     pslr_status status;
     char C;
     pslr_rational_t shutter_speed = {0, 0};
-    uint32_t iso = 0;
+    pslr_rational_t aperture = {0, 0};
+		uint32_t iso = 0;
     uint32_t auto_iso_min = 0;
     uint32_t auto_iso_max = 0;
 
@@ -377,6 +378,19 @@ int servermode_socket(int servermode_timeout) {
                     } else {
                         sprintf(buf, "%d %d %d\n", 0, shutter_speed.nom, shutter_speed.denom);
                         pslr_set_shutter(camhandle, shutter_speed);
+                    }
+                    write_socket_answer(buf);
+                }
+            } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
+                if ( check_camera(camhandle) ) {
+									  aperture.nom = atof(arg) * 10 ;
+										aperture.denom = 10 ;
+                    if (aperture.nom) {
+                        pslr_set_aperture(camhandle, aperture);
+												sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
+                    } else {
+                      	aperture.nom = 0;
+                      	sprintf(buf,"1 Invalid aperture value.\n");
                     }
                     write_socket_answer(buf);
                 }

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -171,7 +171,7 @@ int servermode_socket(int servermode_timeout) {
     char C;
     pslr_rational_t shutter_speed = {0, 0};
     pslr_rational_t aperture = {0, 0};
-		uint32_t iso = 0;
+	uint32_t iso = 0;
     uint32_t auto_iso_min = 0;
     uint32_t auto_iso_max = 0;
 
@@ -383,11 +383,11 @@ int servermode_socket(int servermode_timeout) {
                 }
             } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
                 if ( check_camera(camhandle) ) {
-									  aperture.nom = atof(arg) * 10 ;
-										aperture.denom = 10 ;
+					aperture.nom = atof(arg) * 10 ;
+					aperture.denom = 10 ;
                     if (aperture.nom) {
                         pslr_set_aperture(camhandle, aperture);
-												sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
+						sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
                     } else {
                       	aperture.nom = 0;
                       	sprintf(buf,"1 Invalid aperture value.\n");

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -168,6 +168,7 @@ int servermode_socket(int servermode_timeout) {
     char buf[2100];
     pslr_handle_t camhandle=NULL;
     pslr_status status;
+    pslr_buffer_type buffer_type=PSLR_BUF_DNG;
     char C;
     pslr_rational_t shutter_speed = {0, 0};
     pslr_rational_t aperture = {0, 0};
@@ -345,11 +346,20 @@ int servermode_socket(int servermode_timeout) {
                         write_socket_answer_bin(pImage, imageSize);
                     }
                 }
+            } else if (  (arg = is_string_prefix( client_message, "get_buffer_type")) != NULL ) {
+                if ( buffer_type == PSLR_BUF_PEF ) {
+                    sprintf(buf,"0 PEF\n");
+                } else if ( buffer_type == PSLR_BUF_DNG ) {
+                    sprintf(buf,"0 DNG\n");
+                } else {
+                    sprintf(buf,"1 Invalid buffer type.\n");
+                }
+                write_socket_answer(buf);
             } else if (  (arg = is_string_prefix( client_message, "get_buffer")) != NULL ) {
                 int bufno = atoi(arg);
                 if ( check_camera(camhandle) ) {
                     uint32_t imageSize;
-                    if ( pslr_buffer_open(camhandle, bufno, PSLR_BUF_DNG, 0) ) {
+                    if ( pslr_buffer_open(camhandle, bufno, buffer_type, 0) ) {
                         sprintf(buf, "%d\n", 1);
                         write_socket_answer(buf);
                     } else {
@@ -370,6 +380,17 @@ int servermode_socket(int servermode_timeout) {
                         pslr_buffer_close(camhandle);
                     }
                 }
+            } else if (  (arg = is_string_prefix( client_message, "set_buffer_type")) != NULL ) {
+                if( !strcmp(arg, "PEF") ) {
+                    buffer_type = PSLR_BUF_PEF;
+                    sprintf(buf,"0 PEF\n");
+                } else if( !strcmp(arg, "DNG") ) {
+                    buffer_type = PSLR_BUF_DNG;
+                    sprintf(buf,"0 DNG\n");
+                } else {
+                    sprintf(buf,"1 Invalid buffer type (must be PEF or DNG).\n");
+                }
+                write_socket_answer(buf);
             } else if (  (arg = is_string_prefix( client_message, "set_shutter_speed")) != NULL ) {
                 if ( check_camera(camhandle) ) {
                     shutter_speed = parse_shutter_speed(arg);

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -381,10 +381,10 @@ int servermode_socket(int servermode_timeout) {
                     }
                 }
             } else if (  (arg = is_string_prefix( client_message, "set_buffer_type")) != NULL ) {
-                if( !strcmp(arg, "PEF") ) {
+                if ( !strcmp(arg, "PEF") ) {
                     buffer_type = PSLR_BUF_PEF;
                     sprintf(buf,"0 PEF\n");
-                } else if( !strcmp(arg, "DNG") ) {
+                } else if ( !strcmp(arg, "DNG") ) {
                     buffer_type = PSLR_BUF_DNG;
                     sprintf(buf,"0 DNG\n");
                 } else {

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -171,7 +171,6 @@ int servermode_socket(int servermode_timeout) {
     pslr_buffer_type buffer_type=PSLR_BUF_DNG;
     char C;
     pslr_rational_t shutter_speed = {0, 0};
-    pslr_rational_t aperture = {0, 0};
     uint32_t iso = 0;
     uint32_t auto_iso_min = 0;
     uint32_t auto_iso_max = 0;
@@ -399,19 +398,6 @@ int servermode_socket(int servermode_timeout) {
                     } else {
                         sprintf(buf, "%d %d %d\n", 0, shutter_speed.nom, shutter_speed.denom);
                         pslr_set_shutter(camhandle, shutter_speed);
-                    }
-                    write_socket_answer(buf);
-                }
-            } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
-                if ( check_camera(camhandle) ) {
-                    aperture.nom = atof(arg) * 10;
-                    aperture.denom = 10;
-                    if (aperture.nom) {
-                        pslr_set_aperture(camhandle, aperture);
-                        sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);
-                    } else {
-                        aperture.nom = 0;
-                        sprintf(buf,"1 Invalid aperture value.\n");
                     }
                     write_socket_answer(buf);
                 }

--- a/pktriggercord-servermode.c
+++ b/pktriggercord-servermode.c
@@ -383,8 +383,8 @@ int servermode_socket(int servermode_timeout) {
                 }
             } else if (  (arg = is_string_prefix( client_message, "set_aperture")) != NULL ) {
                 if ( check_camera(camhandle) ) {
-                    aperture.nom = atof(arg) * 10 ;
-                    aperture.denom = 10 ;
+                    aperture.nom = atof(arg) * 10;
+                    aperture.denom = 10;
                     if (aperture.nom) {
                         pslr_set_aperture(camhandle, aperture);
                         sprintf(buf, "%d %.1f\n", 0, aperture.nom / 10.0);


### PR DESCRIPTION
It's useful to be able to download images in PEF rather than DNG, since PEF is compressed and DNG isn't (at least on older Pentax cameras), which is a benefit when downloading multiple images over USB 2.0. Since the buffer type is specified when actually reading the buffer rather than when releasing the shutter, it can be stored as a variable with no need to communicate with the camera when it's changed. 

The default setting is DNG, so it shouldn't affect anything unless explicitly modified.

Tested on a Pentax K10D (connected to a Raspberry Pi 4B) and it seems to work as expected.