### PR TITLE
Makefile: remove external target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ pslr_scsi.o: pslr_scsi_win.c pslr_scsi_linux.c pslr_scsi_openbsd.c
 $(JSONDIR)/js0n.o: $(JSONDIR)/js0n.c $(JSONDIR)/js0n.h
 	$(CC) $(LOCAL_CFLAGS) -fPIC -c $< -o $@
 
-external: $(JSONDIR)/js0n.o
+EXTERNAL=$(JSONDIR)/js0n.o
 
-%.o: %.c %.h external
+%.o: %.c %.h $(EXTERNAL)
 	$(CC) $(LOCAL_CFLAGS) -DPKTDATADIR=\"$(PKTDATADIR)\" -fPIC -c $< -o $@
 
 ifeq ($(ARCH),Win32)


### PR DESCRIPTION
It causes rebuilds on each invocation. Use a variable instead.