### PR TITLE
handle retval of write()

### DIFF
--- a/pktriggercord.c
+++ b/pktriggercord.c
@@ -2129,7 +2129,11 @@ static void save_buffer_single(const char *filename, const pslr_buffer_type imag
             perror("could not open target");
             return;
         }
-        write(fd, pLastPreviewImage, lastPreviewImageSize);
+        ssize_t wr = write(fd, pLastPreviewImage, lastPreviewImageSize);
+        if (wr < 0)
+            perror("could not write to target");
+        else if (wr != lastPreviewImageSize)
+            fprintf(stderr, "short write to target");
         wait_for_gtk_events_pending();
         close(fd);
     }


### PR DESCRIPTION
`write()` can fail and compiler also warns:
```
warning: ignoring return value of 'write' declared with attribute 'warn_unused_result'
```
Fix this.